### PR TITLE
Leave authentication token empty when access key is provided.

### DIFF
--- a/pkg/dataplane/http/session.go
+++ b/pkg/dataplane/http/session.go
@@ -23,7 +23,7 @@ func newSession(parentLogger logger.Logger,
 	accessKey string) (v3io.Session, error) {
 
 	authenticationToken := ""
-	if username != "" && password != "" {
+	if username != "" && password != "" && accessKey == "" {
 		authenticationToken = GenerateAuthenticationToken(username, password)
 	}
 


### PR DESCRIPTION
Because web API rejects requests with both headers with 400 Bad Request:
```
{
	"ErrorCode": -369098782,
	"ErrorMessage": "Invalid web-API request: the request includes headers for both basic-HTTP and access-key (session-key) authentication"
}
```