### PR TITLE
Include full HTTP response in error.

### DIFF
--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -923,7 +923,7 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 
 	// make sure we got expected status
 	if !success {
-		err = v3ioerrors.NewErrorWithStatusCode(fmt.Errorf("Failed %s with status %d", method, statusCode), statusCode)
+		err = v3ioerrors.NewErrorWithStatusCode(fmt.Errorf("Expected a 2xx response status code: %s", response.HTTPResponse.String()), statusCode)
 		goto cleanup
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,7 +2,6 @@ package v3ioerrors
 
 import (
 	"errors"
-	"fmt"
 )
 
 var ErrInvalidTypeConversion = errors.New("Invalid type conversion")
@@ -26,5 +25,5 @@ func (e ErrorWithStatusCode) StatusCode() int {
 }
 
 func (e ErrorWithStatusCode) Error() string {
-	return fmt.Sprintf("%s (%d response code)", e.error.Error(), e.statusCode)
+	return e.error.Error()
 }


### PR DESCRIPTION
Error before:
```
Failed DELETE with status 409 (409 response code)
```
Error after: 
```
HTTP/1.1 409 Conflict
Date: Thu, 06 Jun 2019 08:23:10 GMT
Content-Type: application/json
Content-Length: 61
Connection: keep-alive
Strict-Transport-Security: max-age=15724800; includeSubDomains

{"ErrorCode": -39,"ErrorMessage": "Directory not empty"}
```