### PR TITLE
Make V3IO-GO great again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,47 @@
+# All top-level dirs except for vendor/.
+TOPLEVEL_DIRS=`ls -d ./*/. | grep -v '^./vendor/.$$' | grep -v '^./hack/.$$' | grep -v '^./examples/.$$' | sed 's/\.$$/.../'`
+TOPLEVEL_DIRS_GOFMT_SYNTAX=`ls -d ./*/. | grep -v '^./vendor/.$$'` | grep -v '^./hack/.$$' | grep -v '^./examples/.$$'
+TOPLEVEL_DIRS_IMPI_SYNTAX=`ls -d ./*/. | grep -v '^./vendor/.$$' | grep -v '^./hack/.$$' | grep -v '^./examples/.$$' | sed 's/$$/../'`
+
+.PHONY: check-env
+check-env:
+ifndef V3IO_DATAPLANE_URL
+		$(error V3IO_DATAPLANE_URL is undefined)
+endif
+ifndef V3IO_DATAPLANE_USERNAME
+		$(error V3IO_DATAPLANE_USERNAME is undefined)
+endif
+ifndef V3IO_DATAPLANE_ACCESS_KEY
+		$(error V3IO_DATAPLANE_ACCESS_KEY is undefined)
+endif
+ifndef V3IO_CONTROLPLANE_URL
+		$(error V3IO_CONTROLPLANE_URL is undefined)
+endif
+ifndef V3IO_CONTROLPLANE_USERNAME
+		$(error V3IO_CONTROLPLANE_USERNAME is undefined)
+endif
+ifndef V3IO_CONTROLPLANE_PASSWORD
+		$(error V3IO_CONTROLPLANE_PASSWORD is undefined)
+endif
+
+.PHONY: generate-capnp
+generate-capnp:
+	pushd ./pkg/dataplane/schemas/; ./build; popd
+
+.PHONY: clean
+clean:
+	pushd ./pkg/dataplane/schemas/; ./clean; popd
+
+.PHONY: get
+get:
+	GO111MODULE=on \
+		go get -v -tags "unit integration" $(TOPLEVEL_DIRS)
+
+.PHONY: test
+test: check-env
+	GO111MODULE=on \
+		go test -race -tags unit -count 1 $(TOPLEVEL_DIRS)
+
 .PHONY: lint
 lint:
 	docker run --rm \
@@ -8,3 +52,6 @@ lint:
 		bash /go/src/github.com/v3io/v3io-go/hack/lint.sh
 
 	@echo Done.
+
+.PHONY: build
+build: clean generate-capnp get lint test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Project: v3io-go
+
+## Description:
+**v3io-go** is an interface to V3IO API for Golang
+
+## Prerequisites:
+1. Captain proto compiler
+    * MacOS: `brew install capnp`
+    * Debian / Ubuntu: `apt-get install capnproto`
+    * Other: Follow the guidelines https://capnproto.org/install.html
+
+## Dependencies:
+1. go-capnproto2
+    * `git clone git@github.com:iguazio/go-capnproto2.git`
+
+## Running the tests
+1. **Define the following environment variables:**
+    - V3IO_DATAPLANE_URL=http://<app-node>:8081
+    - V3IO_DATAPLANE_USERNAME=<username>
+    - V3IO_DATAPLANE_ACCESS_KEY=<access-key>
+    - V3IO_CONTROLPLANE_URL=http://<data-node>:8001
+    - V3IO_CONTROLPLANE_USERNAME=<admin-username>
+    - V3IO_CONTROLPLANE_PASSWORD=<admin-password>
+2. Run ``make test``
+3. Alternatively you can pass environment variables inline as you can see in the following example: 
+    ```
+    V3IO_DATAPLANE_URL=http://<app-node>:8081 \
+    V3IO_DATAPLANE_USERNAME=<username> \
+    V3IO_DATAPLANE_ACCESS_KEY=<access-key> \
+    V3IO_CONTROLPLANE_URL=http://<data-node>:8001 \
+    V3IO_CONTROLPLANE_USERNAME=<admin-username> \
+    V3IO_CONTROLPLANE_PASSWORD=<admin-password> \
+    make test
+    ```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/nuclio/errors v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/klauspost/compress v1.4.0 h1:8nsMz3tWa9SWWPL60G1V6CUsf4lLjWLTNEtibhe8
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e h1:+lIPJOWl+jSiJOc70QXJ07+2eg2Jy2EC7Mi11BWujeM=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw=

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -9,6 +9,7 @@ echo Linting imports with impi
 $GOPATH/bin/impi \
     --local github.com/v3io/v3io-go \
     --scheme stdLocalThirdParty \
+    --skip=pkg/dataplane/schemas/node/common \
     ./pkg/...
 
 echo Getting all packages
@@ -43,4 +44,5 @@ $GOPATH/bin/gometalinter.v2 \
     --exclude="should have comment" \
     --skip=pkg/platform/kube/apis \
     --skip=pkg/platform/kube/client \
+    --skip=pkg/dataplane/schemas/node/common \
     ./pkg/...

--- a/pkg/controlplane/http/session.go
+++ b/pkg/controlplane/http/session.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -425,7 +424,9 @@ func (s *session) sendRequest(ctx context.Context, request *request, timeout tim
 
 	if !request.allowErrors {
 		if responseInstance.statusCode >= 300 {
-			return nil, v3ioerrors.NewErrorWithStatusCode(errors.New("Failed to execute HTTP request"),
+			return nil, v3ioerrors.NewErrorWithStatusCode(
+				fmt.Errorf("Failed to execute HTTP request %s/%s.\nResponse code: %d",
+					s.endpoints[0], request.path, responseInstance.statusCode),
 				responseInstance.statusCode)
 		}
 	}

--- a/pkg/controlplane/test/controlplane_test.go
+++ b/pkg/controlplane/test/controlplane_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -34,21 +35,23 @@ func (suite *githubClientSuite) SetupSuite() {
 	newSessionInput.Endpoints = []string{controlplaneURL}
 
 	session, err := v3iochttp.NewSession(suite.logger, &newSessionInput)
-	suite.Require().NoError(err)
+	suite.Require().NoError(err, fmt.Sprintf("\nInput: %v\n", newSessionInput))
 
-	// create a user for the tests
+	// create a unique user for the tests
+	ts := time.Now().Unix()
 	createUserInput := v3ioc.CreateUserInput{}
 	createUserInput.Ctx = suite.ctx
-	createUserInput.FirstName = "Test"
-	createUserInput.LastName = "User"
-	createUserInput.Username = "testuser0"
-	createUserInput.Password = "testpass0"
-	createUserInput.Email = "test@user.com"
+	createUserInput.FirstName = fmt.Sprintf("Test-%d", ts)
+	createUserInput.LastName = fmt.Sprintf("User-%d", ts)
+	createUserInput.Username = fmt.Sprintf("testuser-%d", ts)
+	createUserInput.Password = fmt.Sprintf("testpasswd-%d", ts)
+	createUserInput.Email = fmt.Sprintf("testuser-%d@user.com", ts)
 	createUserInput.Description = "A user created from tests"
 	createUserInput.AssignedPolicies = []string{"Security Admin", "Data", "Application Admin", "Function Admin"}
 
 	// create a user with security session
 	createUserOutput, err := session.CreateUserSync(&createUserInput)
+	suite.Require().NoError(err)
 	suite.Require().NotNil(createUserOutput.ID)
 	suite.userID = createUserOutput.ID
 

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,11 +18,11 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-	"io"
 
 	"github.com/v3io/v3io-go/pkg/dataplane"
-	"github.com/v3io/v3io-go/pkg/errors"
 	"github.com/v3io/v3io-go/pkg/dataplane/schemas/node/common"
+	"github.com/v3io/v3io-go/pkg/errors"
+
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/valyala/fasthttp"
@@ -211,7 +212,7 @@ func (c *context) GetItem(getItemInput *v3io.GetItemInput,
 
 type attributeValuesSection struct {
 	accumulatedPreviousSectionsLength int
-	data node_common_capnp.VnObjectAttributeValuePtr_List
+	data                              node_common_capnp.VnObjectAttributeValuePtr_List
 }
 
 // GetItemSync
@@ -263,7 +264,6 @@ func (c *context) GetItems(getItemsInput *v3io.GetItemsInput,
 	responseChan chan *v3io.Response) (*v3io.Request, error) {
 	return c.sendRequestToWorker(getItemsInput, context, responseChan)
 }
-
 
 // GetItemSync
 func (c *context) GetItemsSync(getItemsInput *v3io.GetItemsInput) (*v3io.Response, error) {
@@ -1124,7 +1124,7 @@ func (c *context) workerEntry(workerIndex int) {
 	}
 }
 
-func readAllCapnpMessages(reader io.Reader) ([]*capnp.Message){
+func readAllCapnpMessages(reader io.Reader) []*capnp.Message {
 	var capnpMessages []*capnp.Message
 	for {
 		msg, err := capnp.NewDecoder(reader).Decode()
@@ -1136,13 +1136,13 @@ func readAllCapnpMessages(reader io.Reader) ([]*capnp.Message){
 	return capnpMessages
 }
 
-func getSectionAndIndex(values []attributeValuesSection, idx int) (section int, resIdx int){
+func getSectionAndIndex(values []attributeValuesSection, idx int) (section int, resIdx int) {
 	if len(values) == 1 {
 		return 0, idx
 	}
-	for i := 1; i<len(values); i++ {
+	for i := 1; i < len(values); i++ {
 		if values[i].accumulatedPreviousSectionsLength > idx {
-			return i,idx - values[i-1].accumulatedPreviousSectionsLength
+			return i, idx - values[i-1].accumulatedPreviousSectionsLength
 		}
 	}
 	return 0, idx
@@ -1159,7 +1159,7 @@ func decodeCapnpAttributes(keyValues node_common_capnp.VnObjectItemsGetMappedKey
 		sectIdx, valIdx := getSectionAndIndex(values, valIdx)
 		value, err := values[sectIdx].data.At(valIdx).Value()
 		if err != nil {
-			return attributes, errors.Wrapf(err,"values[%d].data.At(%d).Value",sectIdx, valIdx )
+			return attributes, errors.Wrapf(err, "values[%d].data.At(%d).Value", sectIdx, valIdx)
 		}
 		switch value.Which() {
 		case node_common_capnp.ExtAttrValue_Which_qword:
@@ -1168,14 +1168,20 @@ func decodeCapnpAttributes(keyValues node_common_capnp.VnObjectItemsGetMappedKey
 			attributes[attributeName] = int(value.Uqword())
 		case node_common_capnp.ExtAttrValue_Which_blob:
 			attributes[attributeName], err = value.Blob()
+			if err != nil {
+				return attributes, errors.Wrapf(err, "unable to get value of BLOB attribute '%s'", attributeName)
+			}
 		case node_common_capnp.ExtAttrValue_Which_str:
 			attributes[attributeName], err = value.Str()
+			if err != nil {
+				return attributes, errors.Wrapf(err, "unable to get value of String attribute '%s'", attributeName)
+			}
 		case node_common_capnp.ExtAttrValue_Which_dfloat:
 			attributes[attributeName] = value.Dfloat()
 		case node_common_capnp.ExtAttrValue_Which_boolean:
 			attributes[attributeName] = value.Boolean()
 		case node_common_capnp.ExtAttrValue_Which_notExists:
-			{}
+			continue // skip
 		default:
 			return attributes, errors.Errorf("getItemsCapnp: %s type for %s attribute is not expected", value.Which().String(), attributeName)
 		}
@@ -1183,7 +1189,7 @@ func decodeCapnpAttributes(keyValues node_common_capnp.VnObjectItemsGetMappedKey
 	return attributes, nil
 }
 
-func (c *context) getItemsParseJSONResponse(response *v3io.Response, getItemsInput *v3io.GetItemsInput) (*v3io.GetItemsOutput, error){
+func (c *context) getItemsParseJSONResponse(response *v3io.Response, getItemsInput *v3io.GetItemsInput) (*v3io.GetItemsOutput, error) {
 
 	getItemsResponse := struct {
 		Items            []map[string]map[string]interface{}
@@ -1223,11 +1229,11 @@ func (c *context) getItemsParseJSONResponse(response *v3io.Response, getItemsInp
 	return &getItemsOutput, nil
 }
 
-func (c *context) getItemsParseCAPNPResponse(response *v3io.Response) (*v3io.GetItemsOutput, error){
-	responseBodyReader  := bytes.NewReader(response.Body())
-	capnpSections := readAllCapnpMessages(responseBodyReader )
+func (c *context) getItemsParseCAPNPResponse(response *v3io.Response) (*v3io.GetItemsOutput, error) {
+	responseBodyReader := bytes.NewReader(response.Body())
+	capnpSections := readAllCapnpMessages(responseBodyReader)
 	if len(capnpSections) < 2 {
-		return  nil, errors.Errorf("getItemsCapnp: Got only %v capnp sections. Expecting at least 2", len(capnpSections))
+		return nil, errors.Errorf("getItemsCapnp: Got only %v capnp sections. Expecting at least 2", len(capnpSections))
 	}
 	cookie := string(response.HeaderPeek("X-v3io-cookie"))
 	getItemsOutput := v3io.GetItemsOutput{
@@ -1238,66 +1244,66 @@ func (c *context) getItemsParseCAPNPResponse(response *v3io.Response) (*v3io.Get
 		return nil, errors.Errorf("getItemsCapnp: Got only %v capnp sections. Expecting at least 2", len(capnpSections))
 	}
 
-	metadataPayload, err := node_common_capnp.ReadRootVnObjectItemsGetResponseMetadataPayload(capnpSections[len(capnpSections) - 1])
+	metadataPayload, err := node_common_capnp.ReadRootVnObjectItemsGetResponseMetadataPayload(capnpSections[len(capnpSections)-1])
 	if err != nil {
-		return nil, errors.Wrap(err,"ReadRootVnObjectItemsGetResponseMetadataPayload")
+		return nil, errors.Wrap(err, "ReadRootVnObjectItemsGetResponseMetadataPayload")
 	}
 	//Keys
 	attributeMap, err := metadataPayload.KeyMap()
-	 if err != nil {
-		return nil, errors.Wrap(err,"metadataPayload.KeyMap")
-	}
-	attributeMapNames,err := attributeMap.Names()
-	 if err != nil {
-		return nil, errors.Wrap(err,"attributeMap.Names")
-	}
-	attributeNamesPtr,err  := attributeMapNames.Arr()
 	if err != nil {
-		return nil, errors.Wrap(err,"attributeMapNames.Arr")
+		return nil, errors.Wrap(err, "metadataPayload.KeyMap")
+	}
+	attributeMapNames, err := attributeMap.Names()
+	if err != nil {
+		return nil, errors.Wrap(err, "attributeMap.Names")
+	}
+	attributeNamesPtr, err := attributeMapNames.Arr()
+	if err != nil {
+		return nil, errors.Wrap(err, "attributeMapNames.Arr")
 	}
 	//Values
 	valueMap, err := metadataPayload.ValueMap()
 	if err != nil {
-		return nil, errors.Wrap(err,"metadataPayload.ValueMap")
+		return nil, errors.Wrap(err, "metadataPayload.ValueMap")
 	}
 	values, err := valueMap.Values()
 	if err != nil {
-		return nil, errors.Wrap(err,"valueMap.Values")
+		return nil, errors.Wrap(err, "valueMap.Values")
 	}
 
 	// Items
 	items, err := metadataPayload.Items()
 	if err != nil {
-		return nil, errors.Wrap(err,"metadataPayload.Items")
+		return nil, errors.Wrap(err, "metadataPayload.Items")
 	}
-	valuesSections :=  make([]attributeValuesSection , len(capnpSections) - 1)
+	valuesSections := make([]attributeValuesSection, len(capnpSections)-1)
 
 	accLength := 0
 	//Additional data sections "in between"
-	for capnpSectionIndex:= 1;capnpSectionIndex < len(capnpSections) - 1; capnpSectionIndex++ {
+	for capnpSectionIndex := 1; capnpSectionIndex < len(capnpSections)-1; capnpSectionIndex++ {
 		data, err := node_common_capnp.ReadRootVnObjectAttributeValueMap(capnpSections[capnpSectionIndex])
 		if err != nil {
-			return nil, errors.Wrap(err,"node_common_capnp.ReadRootVnObjectAttributeValueMap")
+			return nil, errors.Wrap(err, "node_common_capnp.ReadRootVnObjectAttributeValueMap")
 		}
 		dv, err := data.Values()
 		if err != nil {
-			return nil, errors.Wrap(err,"data.Values")
+			return nil, errors.Wrap(err, "data.Values")
 		}
-		accLength = accLength + dv.Len()  
+		accLength = accLength + dv.Len()
 		valuesSections[capnpSectionIndex-1].data = dv
 		valuesSections[capnpSectionIndex-1].accumulatedPreviousSectionsLength = accLength
 	}
-	accLength = accLength + values.Len()  
-	valuesSections[len(capnpSections) - 2].data = values
-	valuesSections[len(capnpSections) - 2].accumulatedPreviousSectionsLength = accLength
+	accLength = accLength + values.Len()
+	valuesSections[len(capnpSections)-2].data = values
+	valuesSections[len(capnpSections)-2].accumulatedPreviousSectionsLength = accLength
 
 	//Read in all the attribute names
 	attributeNamesNumber := attributeNamesPtr.Len()
-	attributeNames := make([]string,attributeNamesNumber)
+	attributeNames := make([]string, attributeNamesNumber)
 	for attributeIndex := 0; attributeIndex < attributeNamesNumber; attributeIndex++ {
 		attributeNames[attributeIndex], err = attributeNamesPtr.At(attributeIndex).Str()
 		if err != nil {
-			return nil, errors.Wrapf(err,"attributeNamesPtr.At(%d) size %d", attributeIndex, attributeNamesNumber)
+			return nil, errors.Wrapf(err, "attributeNamesPtr.At(%d) size %d", attributeIndex, attributeNamesNumber)
 		}
 	}
 
@@ -1306,19 +1312,19 @@ func (c *context) getItemsParseCAPNPResponse(response *v3io.Response) (*v3io.Get
 		itemPtr := items.At(itemIndex)
 		item, err := itemPtr.Item()
 		if err != nil {
-			return nil, errors.Wrap(err,"itemPtr.Item")
+			return nil, errors.Wrap(err, "itemPtr.Item")
 		}
 		name, err := item.Name()
 		if err != nil {
-			return nil, errors.Wrap(err,"item.Name")
+			return nil, errors.Wrap(err, "item.Name")
 		}
 		itemAttributes, err := item.Attrs()
 		if err != nil {
-			return nil, errors.Wrap(err,"item.Attrs")
+			return nil, errors.Wrap(err, "item.Attrs")
 		}
 		ditem, err := decodeCapnpAttributes(itemAttributes, valuesSections, attributeNames)
 		if err != nil {
-			return nil, errors.Wrap(err,"decodeCapnpAttributes")
+			return nil, errors.Wrap(err, "decodeCapnpAttributes")
 		}
 		ditem["__name"] = name
 		getItemsOutput.Items = append(getItemsOutput.Items, ditem)

--- a/pkg/dataplane/http/headers.go
+++ b/pkg/dataplane/http/headers.go
@@ -30,17 +30,11 @@ var getItemHeaders = map[string]string{
 	"X-v3io-function": getItemFunctionName,
 }
 
-// headers for update item
-var getItemsHeaders = map[string]string{
-	"Content-Type":    "application/json",
-	"X-v3io-function": getItemsFunctionName,
-}
-
-// headers for update item
+// headers for get item with captain-proto serialisation
 var getItemsHeadersCapnp = map[string]string{
-	"Content-Type":    "application/json",
+	"Content-Type":                 "application/json",
 	"X-v3io-response-content-type": "capnp",
-	"X-v3io-function": getItemsFunctionName,
+	"X-v3io-function":              getItemsFunctionName,
 }
 
 // headers for create stream

--- a/pkg/dataplane/requestresponse.go
+++ b/pkg/dataplane/requestresponse.go
@@ -72,7 +72,6 @@ func (r *Response) HeaderPeek(key string) []byte {
 	return r.HTTPResponse.Header.Peek(key)
 }
 
-
 func (r *Response) Request() *Request {
 	return &r.RequestResponse.Request
 }

--- a/pkg/dataplane/schemas/clean
+++ b/pkg/dataplane/schemas/clean
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -name *.go -delete
+find . -name "*.go" -delete

--- a/pkg/dataplane/test/sync_test.go
+++ b/pkg/dataplane/test/sync_test.go
@@ -851,7 +851,7 @@ func validateContent(suite *syncContainerTestSuite, content *v3io.Content, expec
 		suite.Require().Empty(content.CreatingTime)
 		suite.Require().Empty(content.GID)
 		suite.Require().Empty(content.UID)
-		suite.Require().Nil(content.Mode)
+		suite.Require().Empty(content.Mode)
 		suite.Require().Nil(content.InodeNumber)
 		suite.Require().Nil(content.LastSequenceID)
 	}
@@ -876,7 +876,7 @@ func validateCommonPrefix(suite *syncContainerTestSuite, prefix *v3io.CommonPref
 		suite.Require().Empty(prefix.CreatingTime)
 		suite.Require().Empty(prefix.GID)
 		suite.Require().Empty(prefix.UID)
-		suite.Require().Nil(prefix.Mode)
+		suite.Require().Empty(prefix.Mode)
 		suite.Require().Nil(prefix.InodeNumber)
 	}
 }

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -83,36 +83,36 @@ type Content struct {
 	LastSequenceID *int   `xml:"LastSequenceId"` // greater than zero for shard files
 	LastModified   string `xml:"LastModified"`   // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
 
-	Mode         V3IOFileMode `xml:"Mode"`         // uint32, e.g. 0100664
-	AccessTime   string       `xml:"AccessTime"`   // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
-	CreatingTime string       `xml:"CreatingTime"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
-	GID          string       `xml:"GID"`          // Hexadecimal representation of GID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
-	UID          string       `xml:"UID"`          // Hexadecimal representation of UID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
-	InodeNumber  *uint32      `xml:"InodeNumber"`  // iNode number
+	Mode         FileMode `xml:"Mode"`         // octal (ListDir) or decimal (GetItems) base, depends on API, e.g. 33204 or 0100664
+	AccessTime   string   `xml:"AccessTime"`   // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
+	CreatingTime string   `xml:"CreatingTime"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
+	GID          string   `xml:"GID"`          // Hexadecimal representation of GID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
+	UID          string   `xml:"UID"`          // Hexadecimal representation of UID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
+	InodeNumber  *uint32  `xml:"InodeNumber"`  // iNode number
 }
 
 type CommonPrefix struct {
-	Prefix       string       `xml:"Prefix"`       // directory name
-	LastModified string       `xml:"LastModified"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
-	AccessTime   string       `xml:"AccessTime"`   // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
-	CreatingTime string       `xml:"CreatingTime"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
-	Mode         V3IOFileMode `xml:"Mode"`         // uint32, e.g. 040775
-	GID          string       `xml:"GID"`          // Hexadecimal representation of GID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
-	UID          string       `xml:"UID"`          // Hexadecimal representation of UID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
-	InodeNumber  *uint32      `xml:"InodeNumber"`  // iNode number
+	Prefix       string   `xml:"Prefix"`       // directory name
+	LastModified string   `xml:"LastModified"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
+	AccessTime   string   `xml:"AccessTime"`   // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
+	CreatingTime string   `xml:"CreatingTime"` // Date in format time.RFC3339: "2019-06-02T14:30:39.18Z"
+	Mode         FileMode `xml:"Mode"`         // octal number, e.g. 040775
+	GID          string   `xml:"GID"`          // Hexadecimal representation of GID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
+	UID          string   `xml:"UID"`          // Hexadecimal representation of UID (e.g. "3e8" -> i.e. "0x3e8" == 1000)
+	InodeNumber  *uint32  `xml:"InodeNumber"`  // iNode number
 }
 
-type V3IOFileMode string
+type FileMode string
 
-func (vfm V3IOFileMode) FileMode() os.FileMode {
+func (vfm FileMode) FileMode() os.FileMode {
 	return mode(vfm)
 }
 
-func (vfm V3IOFileMode) String() string {
+func (vfm FileMode) String() string {
 	return vfm.FileMode().String()
 }
 
-func mode(v3ioFileMode V3IOFileMode) os.FileMode {
+func mode(v3ioFileMode FileMode) os.FileMode {
 	// Convert 16 bit octal representation of V3IO into decimal 32 bit representation of Go
 	mode, err := strconv.ParseUint(string(v3ioFileMode), 8, 32)
 	if err != nil {


### PR DESCRIPTION
- [x] Makefile
- [x] README
- [x] Fix errors exposed by the linter
- [x] Fix the tests and run both data+control plane tests
- [x] Format the source code
- [x] Change FileMode data type to `string` since in some cases API returns it as decimal int while in others it has octal base.