### PR TITLE
IG-13067: Factor http client out of context so that it can be reused independently of it.

### DIFF
--- a/pkg/dataplane/http/container.go
+++ b/pkg/dataplane/http/container.go
@@ -25,6 +25,7 @@ func newContainer(parentLogger logger.Logger,
 
 func (c *container) populateInputFields(input *v3io.DataPlaneInput) {
 	input.ContainerName = c.containerName
+	input.URL = c.session.url
 	input.AuthenticationToken = c.session.authenticationToken
 	input.AccessKey = c.session.accessKey
 }

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -35,46 +35,12 @@ var requestID uint64
 type context struct {
 	logger           logger.Logger
 	requestChan      chan *v3io.Request
-	httpClient       *fasthttp.HostClient
+	httpClient       *fasthttp.Client
 	clusterEndpoints []string
 	numWorkers       int
 }
 
 func NewContext(parentLogger logger.Logger, newContextInput *v3io.NewContextInput) (v3io.Context, error) {
-	var hosts []string
-	var httpEndpointFound, httpsEndpointFound bool
-
-	if len(newContextInput.ClusterEndpoints) == 0 {
-		return nil, errors.New("Zero cluster endpoints provided")
-	}
-
-	// iterate over endpoints which contain scheme
-	for _, clusterEndpoint := range newContextInput.ClusterEndpoints {
-
-		// Return a clearer error if an empty cluster endpoint is provided.
-		if clusterEndpoint == "" {
-			return nil, errors.New("Cluster endpoint may not be empty")
-		}
-
-		parsedClusterEndpoint, err := url.Parse(clusterEndpoint)
-		if err != nil {
-			return nil, err
-		}
-		switch parsedClusterEndpoint.Scheme {
-		case "http":
-			httpEndpointFound = true
-		case "https":
-			httpsEndpointFound = true
-		default:
-			return nil, errors.Errorf("Unsupported endpoint scheme: %s", parsedClusterEndpoint.Scheme)
-		}
-		hosts = append(hosts, parsedClusterEndpoint.Host)
-	}
-
-	if httpEndpointFound && httpsEndpointFound {
-		return nil, errors.New("cannot create a context with a mix of HTTP and HTTPS endpoints")
-	}
-
 	requestChanLen := newContextInput.RequestChanLen
 	if requestChanLen == 0 {
 		requestChanLen = 1024
@@ -95,19 +61,16 @@ func NewContext(parentLogger logger.Logger, newContextInput *v3io.NewContextInpu
 		dialTimeout = fasthttp.DefaultDialTimeout
 	}
 	dialFunction := func(addr string) (net.Conn, error) {
-		return fasthttp.DialTimeout(addMissingPort(addr, httpsEndpointFound), dialTimeout)
+		return fasthttp.DialTimeout(addr, dialTimeout)
 	}
 	newContext := &context{
 		logger: parentLogger.GetChild("context.http"),
-		httpClient: &fasthttp.HostClient{
-			Addr:      strings.Join(hosts, ","),
-			IsTLS:     httpsEndpointFound,
+		httpClient: &fasthttp.Client{
 			TLSConfig: tlsConfig,
 			Dial:      dialFunction,
 		},
-		clusterEndpoints: newContextInput.ClusterEndpoints,
-		requestChan:      make(chan *v3io.Request, requestChanLen),
-		numWorkers:       numWorkers,
+		requestChan: make(chan *v3io.Request, requestChanLen),
+		numWorkers:  numWorkers,
 	}
 
 	for workerIndex := 0; workerIndex < numWorkers; workerIndex++ {
@@ -117,24 +80,11 @@ func NewContext(parentLogger logger.Logger, newContextInput *v3io.NewContextInpu
 	return newContext, nil
 }
 
-// Code from fasthttp library https://github.com/valyala/fasthttp/blob/ea427d2f448aa8abc0b139f638e80184d4b23d9d/client.go#L1596
-// For some reason, this code is skipped when a custom dial function is provided.
-func addMissingPort(addr string, isTLS bool) string {
-	n := strings.Index(addr, ":")
-	if n >= 0 {
-		return addr
-	}
-	port := 80
-	if isTLS {
-		port = 443
-	}
-	return fmt.Sprintf("%s:%d", addr, port)
-}
-
 // create a new session
 func (c *context) NewSession(newSessionInput *v3io.NewSessionInput) (v3io.Session, error) {
 	return newSession(c.logger,
 		c,
+		newSessionInput.URL,
 		newSessionInput.Username,
 		newSessionInput.Password,
 		newSessionInput.AccessKey)
@@ -855,7 +805,7 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 	request := fasthttp.AcquireRequest()
 	response := c.allocateResponse()
 
-	uri, err := c.buildRequestURI(dataPlaneInput.ContainerName, query, path)
+	uri, err := c.buildRequestURI(dataPlaneInput.URL, dataPlaneInput.ContainerName, query, path)
 	if err != nil {
 		return nil, err
 	}
@@ -936,8 +886,8 @@ cleanup:
 	return response, nil
 }
 
-func (c *context) buildRequestURI(containerName string, query string, pathStr string) (*url.URL, error) {
-	uri, err := url.Parse(c.clusterEndpoints[0])
+func (c *context) buildRequestURI(urlString string, containerName string, query string, pathStr string) (*url.URL, error) {
+	uri, err := url.Parse(urlString)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to parse cluster endpoint URL %s", c.clusterEndpoints[0])
 	}

--- a/pkg/dataplane/http/session.go
+++ b/pkg/dataplane/http/session.go
@@ -12,12 +12,14 @@ import (
 type session struct {
 	logger              logger.Logger
 	context             *context
+	url                 string
 	authenticationToken string
 	accessKey           string
 }
 
 func newSession(parentLogger logger.Logger,
 	context *context,
+	url string,
 	username string,
 	password string,
 	accessKey string) (v3io.Session, error) {
@@ -30,6 +32,7 @@ func newSession(parentLogger logger.Logger,
 	return &session{
 		logger:              parentLogger.GetChild("session"),
 		context:             context,
+		url:                 url,
 		authenticationToken: authenticationToken,
 		accessKey:           accessKey,
 	}, nil

--- a/pkg/dataplane/test/test.go
+++ b/pkg/dataplane/test/test.go
@@ -15,6 +15,7 @@ type testSuite struct { // nolint: deadcode
 	suite.Suite
 	logger              logger.Logger
 	container           v3io.Container
+	url                 string
 	containerName       string
 	authenticationToken string
 	accessKey           string
@@ -25,6 +26,7 @@ func (suite *testSuite) SetupSuite() {
 }
 
 func (suite *testSuite) populateDataPlaneInput(dataPlaneInput *v3io.DataPlaneInput) {
+	dataPlaneInput.URL = suite.url
 	dataPlaneInput.ContainerName = suite.containerName
 	dataPlaneInput.AuthenticationToken = suite.authenticationToken
 	dataPlaneInput.AccessKey = suite.accessKey
@@ -34,14 +36,13 @@ func (suite *testSuite) createContext() {
 	var err error
 
 	// create a context
-	suite.container, err = v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{
-		ClusterEndpoints: []string{os.Getenv("V3IO_DATAPLANE_URL")},
-	})
+	suite.container, err = v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{})
 	suite.Require().NoError(err)
 
 	// populate fields that would have been populated by session/container
 	suite.containerName = "bigdata"
 
+	suite.url = os.Getenv("V3IO_DATAPLANE_URL")
 	username := os.Getenv("V3IO_DATAPLANE_USERNAME")
 	password := os.Getenv("V3IO_DATAPLANE_PASSWORD")
 
@@ -55,12 +56,11 @@ func (suite *testSuite) createContext() {
 func (suite *testSuite) createContainer() {
 
 	// create a context
-	context, err := v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{
-		ClusterEndpoints: []string{os.Getenv("V3IO_DATAPLANE_URL")},
-	})
+	context, err := v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{})
 	suite.Require().NoError(err)
 
 	session, err := context.NewSession(&v3io.NewSessionInput{
+		URL:       os.Getenv("V3IO_DATAPLANE_URL"),
 		Username:  os.Getenv("V3IO_DATAPLANE_USERNAME"),
 		Password:  os.Getenv("V3IO_DATAPLANE_PASSWORD"),
 		AccessKey: os.Getenv("V3IO_DATAPLANE_ACCESS_KEY"),

--- a/pkg/dataplane/test/test.go
+++ b/pkg/dataplane/test/test.go
@@ -36,7 +36,7 @@ func (suite *testSuite) createContext() {
 	var err error
 
 	// create a context
-	suite.container, err = v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{})
+	suite.container, err = v3iohttp.NewContext(suite.logger, v3iohttp.NewDefaultClient(), &v3io.NewContextInput{})
 	suite.Require().NoError(err)
 
 	// populate fields that would have been populated by session/container
@@ -56,7 +56,7 @@ func (suite *testSuite) createContext() {
 func (suite *testSuite) createContainer() {
 
 	// create a context
-	context, err := v3iohttp.NewContext(suite.logger, &v3io.NewContextInput{})
+	context, err := v3iohttp.NewContext(suite.logger, v3iohttp.NewDefaultClient(), &v3io.NewContextInput{})
 	suite.Require().NoError(err)
 
 	session, err := context.NewSession(&v3io.NewSessionInput{

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -30,14 +30,14 @@ import (
 //
 
 type NewContextInput struct {
-	ClusterEndpoints []string
-	NumWorkers       int
-	RequestChanLen   int
-	TLSConfig        *tls.Config
-	DialTimeout      time.Duration
+	NumWorkers     int
+	RequestChanLen int
+	TLSConfig      *tls.Config
+	DialTimeout    time.Duration
 }
 
 type NewSessionInput struct {
+	URL       string
 	Username  string
 	Password  string
 	AccessKey string
@@ -53,6 +53,7 @@ type NewContainerInput struct {
 
 type DataPlaneInput struct {
 	Ctx                 context.Context
+	URL                 string
 	ContainerName       string
 	AuthenticationToken string
 	AccessKey           string
@@ -112,8 +113,8 @@ func (vfm FileMode) String() string {
 }
 
 func mode(v3ioFileMode FileMode) os.FileMode {
-	const S_IFMT = 0xf000
-	const IP_OFFMASK = 0x1fff
+	const S_IFMT = 0xf000     // nolint: golint
+	const IP_OFFMASK = 0x1fff // nolint: golint
 
 	// Convert 16 bit octal representation of V3IO into decimal 32 bit representation of Go
 	mode, err := strconv.ParseUint(string(v3ioFileMode), 8, 32)

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -18,11 +18,12 @@ package v3io
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/xml"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/valyala/fasthttp"
 )
 
 //
@@ -30,10 +31,9 @@ import (
 //
 
 type NewContextInput struct {
+	Client         *fasthttp.Client
 	NumWorkers     int
 	RequestChanLen int
-	TLSConfig      *tls.Config
-	DialTimeout    time.Duration
 }
 
 type NewSessionInput struct {


### PR DESCRIPTION
And use Client instead of HostClient in order to support specifying the target URL at request time (as opposed to client creation time).