### PR TITLE
Delete logging of body in debug mode. Log Content-Length instead.

### DIFF
--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -864,8 +864,7 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 	c.logger.DebugWithCtx(dataPlaneInput.Ctx,
 		"Tx",
 		"uri", uriStr,
-		"method", method,
-		"body", string(request.Body()))
+		"method", method)
 
 	if dataPlaneInput.Timeout <= 0 {
 		err = c.httpClient.Do(request, response.HTTPResponse)
@@ -881,8 +880,7 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 
 	c.logger.DebugWithCtx(dataPlaneInput.Ctx,
 		"Rx",
-		"statusCode", statusCode,
-		"body", string(response.HTTPResponse.Body()))
+		"statusCode", statusCode)
 
 	// did we get a 2xx response?
 	success = statusCode >= 200 && statusCode < 300

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -864,7 +864,8 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 	c.logger.DebugWithCtx(dataPlaneInput.Ctx,
 		"Tx",
 		"uri", uriStr,
-		"method", method)
+		"method", method,
+		"body-length", len(body))
 
 	if dataPlaneInput.Timeout <= 0 {
 		err = c.httpClient.Do(request, response.HTTPResponse)
@@ -880,7 +881,8 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 
 	c.logger.DebugWithCtx(dataPlaneInput.Ctx,
 		"Rx",
-		"statusCode", statusCode)
+		"statusCode", statusCode,
+		"Content-Length", response.HTTPResponse.Header.ContentLength())
 
 	// did we get a 2xx response?
 	success = statusCode >= 200 && statusCode < 300
@@ -1210,7 +1212,7 @@ func decodeCapnpAttributes(keyValues node_common_capnp.VnObjectItemsGetMappedKey
 func (c *context) getItemsParseJSONResponse(response *v3io.Response, getItemsInput *v3io.GetItemsInput) (*v3io.GetItemsOutput, error) {
 
 	getItemsResponse := struct {
-		Items            []map[string]map[string]interface{}
+		Items []map[string]map[string]interface{}
 		NextMarker       string
 		LastItemIncluded string
 	}{}


### PR DESCRIPTION
Because:
* It requires reallocating the full body as a string, even when the log level is less verbose than debug.
* It often blows up the log size when debug is on.