### PR TITLE
Refactored consumer group interface

### DIFF
--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -41,13 +41,13 @@ type context struct {
 }
 
 type NewClientInput struct {
-	TlsConfig       *tls.Config
+	TLSConfig       *tls.Config
 	DialTimeout     time.Duration
 	MaxConnsPerHost int
 }
 
 func NewClient(newClientInput *NewClientInput) *fasthttp.Client {
-	tlsConfig := newClientInput.TlsConfig
+	tlsConfig := newClientInput.TLSConfig
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -1,0 +1,101 @@
+package streamconsumergroup
+
+import (
+	"fmt"
+	"github.com/nuclio/errors"
+	"github.com/nuclio/logger"
+	"github.com/rs/xid"
+)
+
+type member struct {
+	id                    string
+	logger                logger.Logger
+	streamConsumerGroup   *streamConsumerGroup
+	stateHandler          *stateHandler
+	sequenceNumberHandler *sequenceNumberHandler
+	handler               Handler
+	session               Session
+}
+
+func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (Member, error) {
+	var err error
+
+	streamConsumerGroupInstance, ok := streamConsumerGroupInterface.(*streamConsumerGroup)
+	if !ok {
+		return nil, errors.Errorf("Expected streamConsumerGroupInterface of type streamConsumerGroup, got %T", streamConsumerGroupInterface)
+	}
+
+	// add uniqueness
+	id := fmt.Sprintf("%s-%s", name, xid.New().String())
+
+	newMember := member{
+		logger:              streamConsumerGroupInstance.logger.GetChild(id),
+		id:                  id,
+		streamConsumerGroup: streamConsumerGroupInstance,
+	}
+
+	// create & start a state handler for the stream
+	newMember.stateHandler, err = newStateHandler(&newMember)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed creating stream consumer group state handler")
+	}
+
+	err = newMember.stateHandler.start()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
+	}
+
+	// create & start an location handler for the stream
+	newMember.sequenceNumberHandler, err = newSequenceNumberHandler(&newMember)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed creating stream consumer group location handler")
+	}
+
+	// if there's no member name, just observe
+	err = newMember.sequenceNumberHandler.start()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
+	}
+
+	return &newMember, nil
+}
+
+func (m *member) Consume(handler Handler) error {
+	m.logger.DebugWith("Starting consumption of consumer group")
+
+	m.handler = handler
+
+	// get the state (holding our shards)
+	sessionState, err := m.stateHandler.getOrCreateSessionState(m.id)
+	if err != nil {
+		return errors.Wrap(err, "Failed getting stream consumer group member state")
+	}
+
+	// create a session object from our state
+	m.session, err = newSession(m, sessionState)
+	if err != nil {
+		return errors.Wrap(err, "Failed creating stream consumer group session")
+	}
+
+	// start it
+	return m.session.start()
+}
+
+func (m *member) Close() error {
+	m.logger.DebugWith("Closing consumer group")
+
+	if err := m.stateHandler.stop(); err != nil {
+		return errors.Wrapf(err, "Failed stopping state handler")
+	}
+	if err := m.sequenceNumberHandler.stop(); err != nil {
+		return errors.Wrapf(err, "Failed stopping location handler")
+	}
+
+	if m.session != nil {
+		if err := m.session.stop(); err != nil {
+			return errors.Wrap(err, "Failed stopping member session")
+		}
+	}
+
+	return nil
+}

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -2,6 +2,7 @@ package streamconsumergroup
 
 import (
 	"fmt"
+
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 	"github.com/rs/xid"

--- a/pkg/dataplane/streamconsumergroup/sequencenumberhandler.go
+++ b/pkg/dataplane/streamconsumergroup/sequencenumberhandler.go
@@ -1,37 +1,33 @@
 package streamconsumergroup
 
 import (
-	"fmt"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/v3io/v3io-go/pkg/common"
-	"github.com/v3io/v3io-go/pkg/dataplane"
-	"github.com/v3io/v3io-go/pkg/errors"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
 )
 
-var errShardNotFound = errors.New("Shard not found")
-var errShardSequenceNumberAttributeNotFound = errors.New("Shard sequenceNumber attribute")
+var ErrShardNotFound = errors.New("Shard not found")
+var ErrShardSequenceNumberAttributeNotFound = errors.New("Shard sequenceNumber attribute")
 
 type sequenceNumberHandler struct {
 	logger                                     logger.Logger
-	streamConsumerGroup                        *streamConsumerGroup
+	member                                     *member
 	markedShardSequenceNumbers                 []uint64
 	markedShardSequenceNumbersLock             sync.RWMutex
 	stopMarkedShardSequenceNumberCommitterChan chan struct{}
 	lastCommittedShardSequenceNumbers          []uint64
 }
 
-func newSequenceNumberHandler(streamConsumerGroup *streamConsumerGroup) (*sequenceNumberHandler, error) {
+func newSequenceNumberHandler(member *member) (*sequenceNumberHandler, error) {
 
 	return &sequenceNumberHandler{
-		logger:                     streamConsumerGroup.logger.GetChild("sequenceNumberHandler"),
-		streamConsumerGroup:        streamConsumerGroup,
-		markedShardSequenceNumbers: make([]uint64, streamConsumerGroup.totalNumShards),
+		logger:                     member.logger.GetChild("sequenceNumberHandler"),
+		member:                     member,
+		markedShardSequenceNumbers: make([]uint64, member.streamConsumerGroup.totalNumShards),
 		stopMarkedShardSequenceNumberCommitterChan: make(chan struct{}, 1),
 	}, nil
 }
@@ -40,7 +36,7 @@ func (snh *sequenceNumberHandler) start() error {
 	snh.logger.DebugWith("Starting sequenceNumber handler")
 
 	// stopped on stop()
-	go snh.markedShardSequenceNumbersCommitter(snh.streamConsumerGroup.config.SequenceNumber.CommitInterval,
+	go snh.markedShardSequenceNumbersCommitter(snh.member.streamConsumerGroup.config.SequenceNumber.CommitInterval,
 		snh.stopMarkedShardSequenceNumberCommitterChan)
 
 	return nil
@@ -66,112 +62,6 @@ func (snh *sequenceNumberHandler) markShardSequenceNumber(shardID int, sequenceN
 	snh.markedShardSequenceNumbersLock.RUnlock()
 
 	return nil
-}
-
-func (snh *sequenceNumberHandler) getShardLocationFromPersistency(shardID int) (string, error) {
-	snh.logger.DebugWith("Getting shard sequenceNumber from persistency", "shardID", shardID)
-
-	shardPath, err := snh.streamConsumerGroup.getShardPath(shardID)
-	if err != nil {
-		return "", errors.Wrapf(err, "Failed getting shard path: %v", shardID)
-	}
-
-	seekShardInput := v3io.SeekShardInput{
-		Path: shardPath,
-	}
-
-	// get the shard sequenceNumber from the item
-	shardSequenceNumber, err := snh.getShardSequenceNumberFromItemAttributes(shardPath)
-	if err != nil {
-
-		// if the error is that the attribute wasn't found, but the shard was found - seek the shard
-		// according to the configuration
-		if err != errShardSequenceNumberAttributeNotFound {
-			return "", errors.Wrap(err, "Failed to get shard sequenceNumber from item attributes")
-		}
-
-		seekShardInput.Type = snh.streamConsumerGroup.config.Claim.RecordBatchFetch.InitialLocation
-	} else {
-
-		// use sequence number
-		seekShardInput.Type = v3io.SeekShardInputTypeSequence
-		seekShardInput.StartingSequenceNumber = shardSequenceNumber + 1
-	}
-
-	return snh.getShardLocationWithSeek(shardPath, &seekShardInput)
-}
-
-// returns the sequenceNumber, an error re: the shard itself and an error re: the attribute in the shard
-func (snh *sequenceNumberHandler) getShardSequenceNumberFromItemAttributes(shardPath string) (uint64, error) {
-	response, err := snh.streamConsumerGroup.container.GetItemSync(&v3io.GetItemInput{
-		Path:           shardPath,
-		AttributeNames: []string{snh.getShardCommittedSequenceNumberAttributeName()},
-	})
-
-	if err != nil {
-		errWithStatusCode, errHasStatusCode := err.(v3ioerrors.ErrorWithStatusCode)
-		if !errHasStatusCode {
-			return 0, errors.Wrap(err, "Got error without status code")
-		}
-
-		if errWithStatusCode.StatusCode() != http.StatusNotFound {
-			return 0, errors.Wrap(err, "Failed getting shard item")
-		}
-
-		// TODO: remove after errors.Is support added
-		snh.logger.DebugWith("Could not find shard, probably doesn't exist yet", "path", shardPath)
-
-		return 0, errShardNotFound
-	}
-
-	defer response.Release()
-
-	getItemOutput := response.Output.(*v3io.GetItemOutput)
-
-	// return the attribute name
-	sequenceNumber, err := getItemOutput.Item.GetFieldUint64(snh.getShardCommittedSequenceNumberAttributeName())
-	if err != nil && err == v3ioerrors.ErrNotFound {
-		return 0, errShardSequenceNumberAttributeNotFound
-	}
-
-	// return the sequenceNumber we found
-	return sequenceNumber, nil
-}
-
-func (snh *sequenceNumberHandler) getShardLocationWithSeek(shardPath string, seekShardInput *v3io.SeekShardInput) (string, error) {
-
-	snh.logger.DebugWith("Seeking shard", "shardPath", shardPath, "seekShardInput", seekShardInput)
-
-	response, err := snh.streamConsumerGroup.container.SeekShardSync(seekShardInput)
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to seek shard")
-	}
-	defer response.Release()
-
-	location := response.Output.(*v3io.SeekShardOutput).Location
-
-	snh.logger.DebugWith("Seek shard succeeded", "shardPath", shardPath, "location", location)
-
-	return location, nil
-}
-
-func (snh *sequenceNumberHandler) getShardCommittedSequenceNumberAttributeName() string {
-	return fmt.Sprintf("__%s_committed_sequence_number", snh.streamConsumerGroup.name)
-}
-
-func (snh *sequenceNumberHandler) setShardSequenceNumberInPersistency(shardID int, sequenceNumber uint64) error {
-	snh.logger.DebugWith("Setting shard sequenceNumber in persistency", "shardID", shardID, "sequenceNumber", sequenceNumber)
-	shardPath, err := snh.streamConsumerGroup.getShardPath(shardID)
-	if err != nil {
-		return errors.Wrapf(err, "Failed getting shard path: %v", shardID)
-	}
-
-	return snh.streamConsumerGroup.container.UpdateItemSync(&v3io.UpdateItemInput{
-		Path: shardPath,
-		Attributes: map[string]interface{}{
-			snh.getShardCommittedSequenceNumberAttributeName(): sequenceNumber,
-		},
-	})
 }
 
 func (snh *sequenceNumberHandler) markedShardSequenceNumbersCommitter(interval time.Duration, stopChan chan struct{}) {
@@ -218,7 +108,7 @@ func (snh *sequenceNumberHandler) commitMarkedShardSequenceNumbers() error {
 			continue
 		}
 
-		if err := snh.setShardSequenceNumberInPersistency(shardID, sequenceNumber); err != nil {
+		if err := snh.member.streamConsumerGroup.setShardSequenceNumberInPersistency(shardID, sequenceNumber); err != nil {
 			snh.logger.WarnWith("Failed committing shard sequenceNumber", "shardID", shardID,
 				"sequenceNumber", sequenceNumber,
 				"err", errors.GetErrorStackString(err, 10))

--- a/pkg/dataplane/streamconsumergroup/statehandler.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler.go
@@ -4,9 +4,10 @@ import (
 	"math"
 	"time"
 
+	"github.com/v3io/v3io-go/pkg/common"
+
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/v3io/v3io-go/pkg/common"
 )
 
 const stateContentsAttributeKey string = "state"

--- a/pkg/dataplane/streamconsumergroup/statehandler.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler.go
@@ -1,19 +1,12 @@
 package streamconsumergroup
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"math"
-	"path"
 	"time"
-
-	"github.com/v3io/v3io-go/pkg/common"
-	"github.com/v3io/v3io-go/pkg/dataplane"
-	"github.com/v3io/v3io-go/pkg/errors"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"github.com/v3io/v3io-go/pkg/common"
 )
 
 const stateContentsAttributeKey string = "state"
@@ -21,18 +14,18 @@ const stateContentsAttributeKey string = "state"
 var errNoFreeShardGroups = errors.New("No free shard groups")
 
 type stateHandler struct {
-	logger              logger.Logger
-	streamConsumerGroup *streamConsumerGroup
-	stopChan            chan struct{}
-	getStateChan        chan chan *State
+	logger       logger.Logger
+	member       *member
+	stopChan     chan struct{}
+	getStateChan chan chan *State
 }
 
-func newStateHandler(streamConsumerGroup *streamConsumerGroup) (*stateHandler, error) {
+func newStateHandler(member *member) (*stateHandler, error) {
 	return &stateHandler{
-		logger:              streamConsumerGroup.logger.GetChild("stateHandler"),
-		streamConsumerGroup: streamConsumerGroup,
-		stopChan:            make(chan struct{}, 1),
-		getStateChan:        make(chan chan *State),
+		logger:       member.logger.GetChild("stateHandler"),
+		member:       member,
+		stopChan:     make(chan struct{}, 1),
+		getStateChan: make(chan chan *State),
 	}, nil
 }
 
@@ -104,7 +97,7 @@ func (sh *stateHandler) refreshStatePeriodically() {
 			}
 
 		// periodically get the state
-		case <-time.After(sh.streamConsumerGroup.config.Session.HeartbeatInterval):
+		case <-time.After(sh.member.streamConsumerGroup.config.Session.HeartbeatInterval):
 			lastState, err = sh.refreshState()
 			if err != nil {
 				sh.logger.WarnWith("Failed refreshing state", "err", errors.GetErrorStackString(err, 10))
@@ -120,7 +113,7 @@ func (sh *stateHandler) refreshStatePeriodically() {
 }
 
 func (sh *stateHandler) refreshState() (*State, error) {
-	return sh.modifyState(func(state *State) (*State, error) {
+	return sh.member.streamConsumerGroup.setState(func(state *State) (*State, error) {
 
 		// remove stale sessions from state
 		if err := sh.removeStaleSessionStates(state); err != nil {
@@ -128,7 +121,7 @@ func (sh *stateHandler) refreshState() (*State, error) {
 		}
 
 		// find our session by member ID
-		sessionState := state.findSessionStateByMemberID(sh.streamConsumerGroup.memberID)
+		sessionState := state.findSessionStateByMemberID(sh.member.id)
 
 		// session already exists - just set the last heartbeat
 		if sessionState != nil {
@@ -153,7 +146,7 @@ func (sh *stateHandler) createSessionState(state *State) error {
 	}
 
 	// assign shards
-	shards, err := sh.assignShards(sh.streamConsumerGroup.maxReplicas, sh.streamConsumerGroup.totalNumShards, state)
+	shards, err := sh.assignShards(sh.member.streamConsumerGroup.maxReplicas, sh.member.streamConsumerGroup.totalNumShards, state)
 	if err != nil {
 		return errors.Wrap(err, "Failed resolving shards for session")
 	}
@@ -163,7 +156,7 @@ func (sh *stateHandler) createSessionState(state *State) error {
 		"state", state)
 
 	state.SessionStates = append(state.SessionStates, &SessionState{
-		MemberID:      sh.streamConsumerGroup.memberID,
+		MemberID:      sh.member.id,
 		LastHeartbeat: time.Now(),
 		Shards:        shards,
 	})
@@ -247,134 +240,6 @@ func (sh *stateHandler) getAssignEmptyShardGroup(replicaShardGroups [][]int, sta
 
 }
 
-func (sh *stateHandler) modifyState(modifier stateModifier) (*State, error) {
-	var modifiedState *State
-
-	backoff := sh.streamConsumerGroup.config.State.ModifyRetry.Backoff
-	attempts := sh.streamConsumerGroup.config.State.ModifyRetry.Attempts
-
-	err := common.RetryFunc(context.TODO(), sh.logger, attempts, nil, &backoff, func(int) (bool, error) {
-		state, mtime, err := sh.getStateFromPersistency()
-		if err != nil && err != v3ioerrors.ErrNotFound {
-			return true, errors.Wrap(err, "Failed getting current state from persistency")
-		}
-
-		if state == nil {
-			state, err = newState()
-			if err != nil {
-				return true, errors.Wrap(err, "Failed to create state")
-			}
-		}
-
-		// for logging
-		previousState := state.deepCopy()
-
-		modifiedState, err = modifier(state)
-		if err != nil {
-			return true, errors.Wrap(err, "Failed modifying state")
-		}
-
-		sh.logger.DebugWith("Modified state, saving",
-			"previousState", previousState,
-			"modifiedState", modifiedState)
-
-		err = sh.setStateInPersistency(modifiedState, mtime)
-		if err != nil {
-			return true, errors.Wrap(err, "Failed setting state in persistency state")
-		}
-
-		return false, nil
-	})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed modifying state, attempts exhausted")
-	}
-
-	return modifiedState, nil
-}
-
-func (sh *stateHandler) getStateFilePath() (string, error) {
-	return path.Join(sh.streamConsumerGroup.streamPath, fmt.Sprintf("%s-state.json", sh.streamConsumerGroup.name)), nil
-}
-
-func (sh *stateHandler) setStateInPersistency(state *State, mtime *int) error {
-	stateFilePath, err := sh.getStateFilePath()
-	if err != nil {
-		return errors.Wrap(err, "Failed getting state file path")
-	}
-
-	stateContents, err := json.Marshal(state)
-	if err != nil {
-		return errors.Wrap(err, "Failed marshaling state file contents")
-	}
-
-	var condition string
-	if mtime != nil {
-		condition = fmt.Sprintf("__mtime_nsecs == %v", *mtime)
-	}
-
-	err = sh.streamConsumerGroup.container.UpdateItemSync(&v3io.UpdateItemInput{
-		Path:      stateFilePath,
-		Condition: condition,
-		Attributes: map[string]interface{}{
-			stateContentsAttributeKey: string(stateContents),
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "Failed setting state in persistency")
-	}
-
-	return nil
-}
-
-func (sh *stateHandler) getStateFromPersistency() (*State, *int, error) {
-	stateFilePath, err := sh.getStateFilePath()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed getting state file path")
-	}
-
-	response, err := sh.streamConsumerGroup.container.GetItemSync(&v3io.GetItemInput{
-		Path:           stateFilePath,
-		AttributeNames: []string{"__mtime_nsecs", stateContentsAttributeKey},
-	})
-
-	if err != nil {
-		errWithStatusCode, errHasStatusCode := err.(v3ioerrors.ErrorWithStatusCode)
-		if !errHasStatusCode {
-			return nil, nil, errors.Wrap(err, "Got error without status code")
-		}
-
-		if errWithStatusCode.StatusCode() != 404 {
-			return nil, nil, errors.Wrap(err, "Failed getting state item")
-		}
-
-		return nil, nil, v3ioerrors.ErrNotFound
-	}
-
-	defer response.Release()
-
-	getItemOutput := response.Output.(*v3io.GetItemOutput)
-
-	stateContents, err := getItemOutput.Item.GetFieldString(stateContentsAttributeKey)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Failed getting state attribute")
-	}
-
-	var state State
-
-	err = json.Unmarshal([]byte(stateContents), &state)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "Failed unmarshalling state contents: %s", stateContents)
-	}
-
-	stateMtime, err := getItemOutput.Item.GetFieldInt("__mtime_nsecs")
-	if err != nil {
-		return nil, nil, errors.New("Failed getting mtime attribute")
-	}
-
-	return &state, &stateMtime, nil
-}
-
 func (sh *stateHandler) removeStaleSessionStates(state *State) error {
 
 	// clear out the sessions since we only want the valid sessions
@@ -383,7 +248,7 @@ func (sh *stateHandler) removeStaleSessionStates(state *State) error {
 	for _, sessionState := range state.SessionStates {
 
 		// check if the last heartbeat happened prior to the session timeout
-		if time.Since(sessionState.LastHeartbeat) < sh.streamConsumerGroup.config.Session.Timeout {
+		if time.Since(sessionState.LastHeartbeat) < sh.member.streamConsumerGroup.config.Session.Timeout {
 			activeSessionStates = append(activeSessionStates, sessionState)
 		} else {
 			sh.logger.DebugWith("Removing stale member",

--- a/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
+++ b/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
@@ -1,7 +1,12 @@
 package streamconsumergroup
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/v3io/v3io-go/pkg/common"
+	v3ioerrors "github.com/v3io/v3io-go/pkg/errors"
+	"net/http"
 	"path"
 	"strconv"
 
@@ -9,48 +14,37 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
-	"github.com/rs/xid"
 )
 
 type streamConsumerGroup struct {
-	name                  string
-	memberID              string
-	logger                logger.Logger
-	config                *Config
-	streamPath            string
-	maxReplicas           int
-	stateHandler          *stateHandler
-	sequenceNumberHandler *sequenceNumberHandler
-	container             v3io.Container
-	handler               Handler
-	session               Session
-	totalNumShards        int
+	logger         logger.Logger
+	name           string
+	config         *Config
+	container      v3io.Container
+	streamPath     string
+	maxReplicas    int
+	totalNumShards int
 }
 
 func NewStreamConsumerGroup(parentLogger logger.Logger,
 	name string,
-	memberName string,
 	config *Config,
+	container v3io.Container,
 	streamPath string,
-	maxReplicas int,
-	container v3io.Container) (StreamConsumerGroup, error) {
+	maxReplicas int) (StreamConsumerGroup, error) {
 	var err error
-
-	// add uniqueness
-	memberID := fmt.Sprintf("%s-%s", memberName, xid.New().String())
 
 	if config == nil {
 		config = NewConfig()
 	}
 
 	newStreamConsumerGroup := streamConsumerGroup{
+		logger:      parentLogger.GetChild(name),
 		name:        name,
-		memberID:    memberID,
-		logger:      parentLogger.GetChild(fmt.Sprintf("%s-%s", name, memberID)),
 		config:      config,
+		container:   container,
 		streamPath:  streamPath,
 		maxReplicas: maxReplicas,
-		container:   container,
 	}
 
 	// get the total number of shards for this stream
@@ -59,69 +53,21 @@ func NewStreamConsumerGroup(parentLogger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to get total number of shards")
 	}
 
-	// create & start a state handler for the stream
-	newStreamConsumerGroup.stateHandler, err = newStateHandler(&newStreamConsumerGroup)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed creating stream consumer group state handler")
-	}
-
-	err = newStreamConsumerGroup.stateHandler.start()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
-	}
-
-	// create & start an location handler for the stream
-	newStreamConsumerGroup.sequenceNumberHandler, err = newSequenceNumberHandler(&newStreamConsumerGroup)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed creating stream consumer group location handler")
-	}
-
-	err = newStreamConsumerGroup.sequenceNumberHandler.start()
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
-	}
-
 	return &newStreamConsumerGroup, nil
 }
 
-func (scg *streamConsumerGroup) Consume(handler Handler) error {
-	scg.logger.DebugWith("Starting consumption of consumer group")
+func (scg *streamConsumerGroup) GetState() (*State, error) {
+	state, _, err := scg.getStateFromPersistency()
 
-	scg.handler = handler
-
-	// get the state (holding our shards)
-	sessionState, err := scg.stateHandler.getOrCreateSessionState(scg.memberID)
-	if err != nil {
-		return errors.Wrap(err, "Failed getting stream consumer group member state")
-	}
-
-	// create a session object from our state
-	scg.session, err = newSession(scg, sessionState)
-	if err != nil {
-		return errors.Wrap(err, "Failed creating stream consumer group session")
-	}
-
-	// start it
-	return scg.session.start()
+	return state, err
 }
 
-func (scg *streamConsumerGroup) Close() error {
-	scg.logger.DebugWith("Closing consumer group")
+func (scg *streamConsumerGroup) GetShardSequenceNumber(shardID int) (uint64, error) {
+	return scg.getShardSequenceNumberFromPersistency(shardID)
+}
 
-	if err := scg.stateHandler.stop(); err != nil {
-		return errors.Wrapf(err, "Failed stopping state handler")
-	}
-	if err := scg.sequenceNumberHandler.stop(); err != nil {
-		return errors.Wrapf(err, "Failed stopping location handler")
-	}
-
-	if scg.session != nil {
-		if err := scg.session.stop(); err != nil {
-			return errors.Wrap(err, "Failed stopping member session")
-		}
-	}
-
-	return nil
+func (scg *streamConsumerGroup) GetNumShards() (int, error) {
+	return scg.totalNumShards, nil
 }
 
 func (scg *streamConsumerGroup) getShardPath(shardID int) (string, error) {
@@ -139,4 +85,230 @@ func (scg *streamConsumerGroup) getTotalNumberOfShards() (int, error) {
 	defer response.Release()
 
 	return response.Output.(*v3io.DescribeStreamOutput).ShardCount, nil
+}
+
+func (scg *streamConsumerGroup) setState(modifier stateModifier) (*State, error) {
+	var modifiedState *State
+
+	backoff := scg.config.State.ModifyRetry.Backoff
+	attempts := scg.config.State.ModifyRetry.Attempts
+
+	err := common.RetryFunc(context.TODO(), scg.logger, attempts, nil, &backoff, func(int) (bool, error) {
+		state, mtime, err := scg.getStateFromPersistency()
+		if err != nil && err != v3ioerrors.ErrNotFound {
+			return true, errors.Wrap(err, "Failed getting current state from persistency")
+		}
+
+		if state == nil {
+			state, err = newState()
+			if err != nil {
+				return true, errors.Wrap(err, "Failed to create state")
+			}
+		}
+
+		// for logging
+		previousState := state.deepCopy()
+
+		modifiedState, err = modifier(state)
+		if err != nil {
+			return true, errors.Wrap(err, "Failed modifying state")
+		}
+
+		scg.logger.DebugWith("Modified state, saving",
+			"previousState", previousState,
+			"modifiedState", modifiedState)
+
+		err = scg.setStateInPersistency(modifiedState, mtime)
+		if err != nil {
+			return true, errors.Wrap(err, "Failed setting state in persistency state")
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed modifying state, attempts exhausted")
+	}
+
+	return modifiedState, nil
+}
+
+func (scg *streamConsumerGroup) setStateInPersistency(state *State, mtime *int) error {
+	stateContents, err := json.Marshal(state)
+	if err != nil {
+		return errors.Wrap(err, "Failed marshaling state file contents")
+	}
+
+	var condition string
+	if mtime != nil {
+		condition = fmt.Sprintf("__mtime_nsecs == %v", *mtime)
+	}
+
+	err = scg.container.UpdateItemSync(&v3io.UpdateItemInput{
+		Path:      scg.getStateFilePath(),
+		Condition: condition,
+		Attributes: map[string]interface{}{
+			stateContentsAttributeKey: string(stateContents),
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed setting state in persistency")
+	}
+
+	return nil
+}
+
+func (scg *streamConsumerGroup) getStateFromPersistency() (*State, *int, error) {
+	response, err := scg.container.GetItemSync(&v3io.GetItemInput{
+		Path:           scg.getStateFilePath(),
+		AttributeNames: []string{"__mtime_nsecs", stateContentsAttributeKey},
+	})
+
+	if err != nil {
+		errWithStatusCode, errHasStatusCode := err.(v3ioerrors.ErrorWithStatusCode)
+		if !errHasStatusCode {
+			return nil, nil, errors.Wrap(err, "Got error without status code")
+		}
+
+		if errWithStatusCode.StatusCode() != 404 {
+			return nil, nil, errors.Wrap(err, "Failed getting state item")
+		}
+
+		return nil, nil, v3ioerrors.ErrNotFound
+	}
+
+	defer response.Release()
+
+	getItemOutput := response.Output.(*v3io.GetItemOutput)
+
+	stateContents, err := getItemOutput.Item.GetFieldString(stateContentsAttributeKey)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "Failed getting state attribute")
+	}
+
+	var state State
+
+	err = json.Unmarshal([]byte(stateContents), &state)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Failed unmarshalling state contents: %s", stateContents)
+	}
+
+	stateMtime, err := getItemOutput.Item.GetFieldInt("__mtime_nsecs")
+	if err != nil {
+		return nil, nil, errors.New("Failed getting mtime attribute")
+	}
+
+	return &state, &stateMtime, nil
+}
+
+func (scg *streamConsumerGroup) getStateFilePath() string {
+	return path.Join(scg.streamPath, fmt.Sprintf("%s-state.json", scg.name))
+}
+
+func (scg *streamConsumerGroup) getShardLocationFromPersistency(shardID int) (string, error) {
+	scg.logger.DebugWith("Getting shard sequenceNumber from persistency", "shardID", shardID)
+
+	seekShardInput := v3io.SeekShardInput{}
+
+	// get the shard sequenceNumber from the item
+	shardSequenceNumber, err := scg.getShardSequenceNumberFromPersistency(shardID)
+	if err != nil {
+
+		// if the error is that the attribute wasn't found, but the shard was found - seek the shard
+		// according to the configuration
+		if err != ErrShardSequenceNumberAttributeNotFound {
+			return "", errors.Wrap(err, "Failed to get shard sequenceNumber from item attributes")
+		}
+
+		seekShardInput.Type = scg.config.Claim.RecordBatchFetch.InitialLocation
+	} else {
+
+		// use sequence number
+		seekShardInput.Type = v3io.SeekShardInputTypeSequence
+		seekShardInput.StartingSequenceNumber = shardSequenceNumber + 1
+	}
+
+	seekShardInput.Path, err = scg.getShardPath(shardID)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed getting shard path: %v", shardID)
+	}
+
+	return scg.getShardLocationWithSeek(&seekShardInput)
+}
+
+// returns the sequenceNumber, an error re: the shard itself and an error re: the attribute in the shard
+func (scg *streamConsumerGroup) getShardSequenceNumberFromPersistency(shardID int) (uint64, error) {
+	shardPath, err := scg.getShardPath(shardID)
+	if err != nil {
+		return 0, errors.Wrapf(err, "Failed getting shard path: %v", shardID)
+	}
+
+	response, err := scg.container.GetItemSync(&v3io.GetItemInput{
+		Path:           shardPath,
+		AttributeNames: []string{scg.getShardCommittedSequenceNumberAttributeName()},
+	})
+
+	if err != nil {
+		errWithStatusCode, errHasStatusCode := err.(v3ioerrors.ErrorWithStatusCode)
+		if !errHasStatusCode {
+			return 0, errors.Wrap(err, "Got error without status code")
+		}
+
+		if errWithStatusCode.StatusCode() != http.StatusNotFound {
+			return 0, errors.Wrap(err, "Failed getting shard item")
+		}
+
+		// TODO: remove after errors.Is support added
+		scg.logger.DebugWith("Could not find shard, probably doesn't exist yet", "path", shardPath)
+
+		return 0, ErrShardNotFound
+	}
+
+	defer response.Release()
+
+	getItemOutput := response.Output.(*v3io.GetItemOutput)
+
+	// return the attribute name
+	sequenceNumber, err := getItemOutput.Item.GetFieldUint64(scg.getShardCommittedSequenceNumberAttributeName())
+	if err != nil && err == v3ioerrors.ErrNotFound {
+		return 0, ErrShardSequenceNumberAttributeNotFound
+	}
+
+	// return the sequenceNumber we found
+	return sequenceNumber, nil
+}
+
+func (scg *streamConsumerGroup) getShardLocationWithSeek(seekShardInput *v3io.SeekShardInput) (string, error) {
+	scg.logger.DebugWith("Seeking shard", "shardPath", seekShardInput.Path, "seekShardInput", seekShardInput)
+
+	response, err := scg.container.SeekShardSync(seekShardInput)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to seek shard")
+	}
+	defer response.Release()
+
+	location := response.Output.(*v3io.SeekShardOutput).Location
+
+	scg.logger.DebugWith("Seek shard succeeded", "shardPath", seekShardInput.Path, "location", location)
+
+	return location, nil
+}
+
+func (scg *streamConsumerGroup) getShardCommittedSequenceNumberAttributeName() string {
+	return fmt.Sprintf("__%s_committed_sequence_number", scg.name)
+}
+
+func (scg *streamConsumerGroup) setShardSequenceNumberInPersistency(shardID int, sequenceNumber uint64) error {
+	scg.logger.DebugWith("Setting shard sequenceNumber in persistency", "shardID", shardID, "sequenceNumber", sequenceNumber)
+	shardPath, err := scg.getShardPath(shardID)
+	if err != nil {
+		return errors.Wrapf(err, "Failed getting shard path: %v", shardID)
+	}
+
+	return scg.container.UpdateItemSync(&v3io.UpdateItemInput{
+		Path: shardPath,
+		Attributes: map[string]interface{}{
+			scg.getShardCommittedSequenceNumberAttributeName(): sequenceNumber,
+		},
+	})
 }

--- a/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
+++ b/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/v3io/v3io-go/pkg/common"
-	v3ioerrors "github.com/v3io/v3io-go/pkg/errors"
 	"net/http"
 	"path"
 	"strconv"
 
+	"github.com/v3io/v3io-go/pkg/common"
 	"github.com/v3io/v3io-go/pkg/dataplane"
+	v3ioerrors "github.com/v3io/v3io-go/pkg/errors"
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"

--- a/pkg/dataplane/streamconsumergroup/types.go
+++ b/pkg/dataplane/streamconsumergroup/types.go
@@ -37,6 +37,12 @@ type RecordBatch struct {
 }
 
 type StreamConsumerGroup interface {
+	GetState() (*State, error)
+	GetShardSequenceNumber(int) (uint64, error)
+	GetNumShards() (int, error)
+}
+
+type Member interface {
 	Consume(Handler) error
 	Close() error
 }


### PR DESCRIPTION
1. StreamConsumerGroup is now a stateless object with which all access to the persistency is performed (can be used to retreive information about a consumer group)
2. All "stateful" components of the StreamConsumerGroup moved to the "Member" - a new object introduced that holds the sequence number handler, state handler, etc