### PR TITLE
Update itemcursor current error when GetItemsSync returns an error

### DIFF
--- a/pkg/dataplane/itemscursor.go
+++ b/pkg/dataplane/itemscursor.go
@@ -78,6 +78,7 @@ func (ic *ItemsCursor) NextItemSync() (Item, error) {
 	// invoke get items
 	newResponse, err := ic.container.GetItemsSync(ic.getItemsInput)
 	if err != nil {
+		ic.currentError = err
 		return nil, err
 	}
 


### PR DESCRIPTION
`currentError` was not set anywhere in `itemscursor`