### PR TITLE
Include response in err struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 .PHONY: test
 test: check-env
 	GO111MODULE=on \
-		go test -race -tags unit -count 1 ./...
+		go test -race -tags unit -count 1 -parallel 1 ./...
 
 .PHONY: lint
 lint:

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -341,7 +341,19 @@ func (c *context) GetItemsSync(getItemsInput *v3io.GetItemsInput) (*v3io.Respons
 		false)
 
 	if err != nil {
-		return nil, err
+		errorWithStatusAndResponse, ok := err.(v3ioerrors.ErrorWithStatusCodeAndResponse)
+		if !ok {
+			return nil, err
+		}
+		if errorWithStatusAndResponse.Response() == nil || errorWithStatusAndResponse.Response().HTTPResponse == nil {
+			return nil, err
+		}
+
+		// if error has included response - attempt to parse it
+		// unlike regular response, there is no need to release response from `errorWithStatusAndResponse`
+		response = errorWithStatusAndResponse.Response()
+		response.Output, _ = c.getItemsParseJSONResponse(response, getItemsInput)
+		return response, err
 	}
 
 	contentType := string(response.HeaderPeek("Content-Type"))
@@ -1004,7 +1016,20 @@ func (c *context) sendRequestAndXMLUnmarshal(dataPlaneInput *v3io.DataPlaneInput
 
 	response, err := c.sendRequest(dataPlaneInput, method, path, query, headers, body, false)
 	if err != nil {
-		return nil, err
+		errorWithStatusAndResponse, ok := err.(v3ioerrors.ErrorWithStatusCodeAndResponse)
+		if !ok {
+			return nil, err
+		}
+		if errorWithStatusAndResponse.Response() == nil || errorWithStatusAndResponse.Response().HTTPResponse == nil {
+			return nil, err
+		}
+
+		// if error has included response - attempt to parse it
+		// unlike regular response, there is no need to release response from `errorWithStatusAndResponse`
+		response = errorWithStatusAndResponse.Response()
+		_ = xml.Unmarshal(response.Body(), output)
+		response.Output = output
+		return response, err
 	}
 
 	// unmarshal the body into the output
@@ -1116,11 +1141,18 @@ func (c *context) sendRequest(dataPlaneInput *v3io.DataPlaneInput,
 	// make sure we got expected status
 	if !success {
 		var re = regexp.MustCompile(".*X-V3io-Session-Key:.*")
+
+		// Include response in error only if caller has requested it
+		var _response *v3io.Response
+		if !releaseResponse {
+			_response = response
+		}
 		sanitizedRequest := re.ReplaceAllString(request.String(), "X-V3io-Session-Key: SANITIZED")
-		err = v3ioerrors.NewErrorWithStatusCode(
+		err = v3ioerrors.NewErrorWithStatusCodeAndResponse(
 			fmt.Errorf("Expected a 2xx response status code: %s\nRequest details:\n%s",
 				response.HTTPResponse.String(), sanitizedRequest),
-			statusCode)
+			statusCode,
+			_response)
 		goto cleanup
 	}
 

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -344,6 +344,7 @@ func (c *context) GetItemsSync(getItemsInput *v3io.GetItemsInput) (*v3io.Respons
 
 		// In case of an error, response is (optionally) returned as a part of an error
 		// We want to extract it, parse it and return to the caller along with the original error
+		// IMPORTANT: if response is present it's the responsibility of a caller to release it
 		response = c.extractResponseFromError(&getItemsInput.DataPlaneInput, err)
 		if response != nil {
 			_ = c.parseGetItemsResponse(getItemsInput, response)
@@ -1003,6 +1004,7 @@ func (c *context) sendRequestAndXMLUnmarshal(dataPlaneInput *v3io.DataPlaneInput
 		response = c.extractResponseFromError(dataPlaneInput, err)
 
 		// attempt to parse the response if it's passed along with the error
+		// IMPORTANT: if response is present it's the responsibility of a caller to release it
 		if response != nil {
 			_ = xml.Unmarshal(response.Body(), output)
 			response.Output = output
@@ -1624,8 +1626,7 @@ func (c *context) extractResponseFromError(dataPlaneInput *v3io.DataPlaneInput, 
 	if !ok {
 		return nil
 	}
-	if errorWithStatusAndResponse.Response() == nil ||
-		errorWithStatusAndResponse.Response().(*v3io.Response).HTTPResponse == nil {
+	if errorWithStatusAndResponse.Response() == nil {
 		return nil
 	}
 

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -343,7 +343,7 @@ func (c *context) GetItemsSync(getItemsInput *v3io.GetItemsInput) (*v3io.Respons
 	if err != nil {
 
 		// In case of an error, response is (optionally) returned as a part of an error
-		// We want to extract it, parse it and return to the caller along with the original error
+		// We want to extract, parse and return it to the caller along with the original error
 		// IMPORTANT: if response is present it's the responsibility of a caller to release it
 		response = c.extractResponseFromError(&getItemsInput.DataPlaneInput, err)
 		if response != nil {
@@ -1000,7 +1000,7 @@ func (c *context) sendRequestAndXMLUnmarshal(dataPlaneInput *v3io.DataPlaneInput
 	if err != nil {
 
 		// In case of an error, response is (optionally) returned as a part of an error
-		// We want to extract it, parse it and return to the caller along with the original error
+		// We want to extract, parse and return it to the caller along with the original error
 		response = c.extractResponseFromError(dataPlaneInput, err)
 
 		// attempt to parse the response if it's passed along with the error

--- a/pkg/dataplane/http/context.go
+++ b/pkg/dataplane/http/context.go
@@ -341,38 +341,17 @@ func (c *context) GetItemsSync(getItemsInput *v3io.GetItemsInput) (*v3io.Respons
 		false)
 
 	if err != nil {
-		if !getItemsInput.DataPlaneInput.IncludeResponseInError {
-			return nil, err
-		}
-		errorWithStatusAndResponse, ok := err.(v3ioerrors.ErrorWithStatusCodeAndResponse)
-		if !ok {
-			return nil, err
-		}
-		if errorWithStatusAndResponse.Response() == nil || errorWithStatusAndResponse.Response().HTTPResponse == nil {
-			return nil, err
-		}
 
-		// if error has included response - attempt to parse it
-		response = errorWithStatusAndResponse.Response()
-		response.Output, _ = c.getItemsParseJSONResponse(response, getItemsInput)
+		// In case of an error, response is (optionally) returned as a part of an error
+		// We want to extract it, parse it and return to the caller along with the original error
+		response = c.extractResponseFromError(&getItemsInput.DataPlaneInput, err)
+		if response != nil {
+			_ = c.parseGetItemsResponse(getItemsInput, response)
+		}
 		return response, err
 	}
 
-	contentType := string(response.HeaderPeek("Content-Type"))
-
-	if contentType != "application/octet-capnp" {
-		c.logger.DebugWithCtx(getItemsInput.Ctx, "Body", "body", string(response.Body()))
-		response.Output, err = c.getItemsParseJSONResponse(response, getItemsInput)
-	} else {
-		var withWildcard bool
-		for _, attributeName := range getItemsInput.AttributeNames {
-			if attributeName == "*" || attributeName == "**" {
-				withWildcard = true
-				break
-			}
-		}
-		response.Output, err = c.getItemsParseCAPNPResponse(response, withWildcard)
-	}
+	err = c.parseGetItemsResponse(getItemsInput, response)
 	return response, err
 }
 
@@ -1018,21 +997,16 @@ func (c *context) sendRequestAndXMLUnmarshal(dataPlaneInput *v3io.DataPlaneInput
 
 	response, err := c.sendRequest(dataPlaneInput, method, path, query, headers, body, false)
 	if err != nil {
-		if !dataPlaneInput.IncludeResponseInError {
-			return nil, err
-		}
-		errorWithStatusAndResponse, ok := err.(v3ioerrors.ErrorWithStatusCodeAndResponse)
-		if !ok {
-			return nil, err
-		}
-		if errorWithStatusAndResponse.Response() == nil || errorWithStatusAndResponse.Response().HTTPResponse == nil {
-			return nil, err
-		}
 
-		// if error has included response - attempt to parse it
-		response = errorWithStatusAndResponse.Response()
-		_ = xml.Unmarshal(response.Body(), output)
-		response.Output = output
+		// In case of an error, response is (optionally) returned as a part of an error
+		// We want to extract it, parse it and return to the caller along with the original error
+		response = c.extractResponseFromError(dataPlaneInput, err)
+
+		// attempt to parse the response if it's passed along with the error
+		if response != nil {
+			_ = xml.Unmarshal(response.Body(), output)
+			response.Output = output
+		}
 		return response, err
 	}
 
@@ -1640,6 +1614,44 @@ func (c *context) getItemsParseCAPNPResponse(response *v3io.Response, withWildca
 		getItemsOutput.Items = append(getItemsOutput.Items, ditem)
 	}
 	return &getItemsOutput, nil
+}
+
+func (c *context) extractResponseFromError(dataPlaneInput *v3io.DataPlaneInput, err error) *v3io.Response {
+	if !dataPlaneInput.IncludeResponseInError {
+		return nil
+	}
+	errorWithStatusAndResponse, ok := err.(v3ioerrors.ErrorWithStatusCodeAndResponse)
+	if !ok {
+		return nil
+	}
+	if errorWithStatusAndResponse.Response() == nil ||
+		errorWithStatusAndResponse.Response().(*v3io.Response).HTTPResponse == nil {
+		return nil
+	}
+
+	return errorWithStatusAndResponse.Response().(*v3io.Response)
+}
+
+func (c *context) parseGetItemsResponse(getItemsInput *v3io.GetItemsInput, response *v3io.Response) error {
+
+	contentType := string(response.HeaderPeek("Content-Type"))
+
+	var err error
+	if contentType != "application/octet-capnp" {
+		c.logger.DebugWithCtx(getItemsInput.Ctx, "Body", "body", string(response.Body()))
+		response.Output, err = c.getItemsParseJSONResponse(response, getItemsInput)
+	} else {
+		var withWildcard bool
+		for _, attributeName := range getItemsInput.AttributeNames {
+			if attributeName == "*" || attributeName == "**" {
+				withWildcard = true
+				break
+			}
+		}
+		response.Output, err = c.getItemsParseCAPNPResponse(response, withWildcard)
+	}
+
+	return err
 }
 
 // parsing the mtime from a header of the form `__mtime_secs==1581605100 and __mtime_nsecs==498349956`

--- a/pkg/dataplane/test/sync_test.go
+++ b/pkg/dataplane/test/sync_test.go
@@ -901,48 +901,7 @@ func (suite *syncKVTestSuite) TestPutItems() {
 func (suite *syncKVTestSuite) TestScatteredCursor() {
 	path := "/emd0"
 
-	scatteredItemKeys := []string{"louise", "karen"}
-	items := map[string]map[string]interface{}{
-		"bob":                {"age": 42, "feature": "mustache"},
-		"linda":              {"age": 41, "feature": "singing"},
-		"natan":              {"age": 35, "feature": "one leg"},
-		"donald":             {"age": 20, "feature": "teeth"},
-		scatteredItemKeys[0]: {"timestamp": time.Now().UnixNano(), "blob0": randomString(60000)},
-		scatteredItemKeys[1]: {"timestamp": time.Now().UnixNano(), "blob0": randomString(60000)},
-	}
-
-	putItemsInput := &v3io.PutItemsInput{
-		Path:  path,
-		Items: items,
-	}
-
-	// Store initial items
-	suite.populateDataPlaneInput(&putItemsInput.DataPlaneInput)
-	response, err := suite.container.PutItemsSync(putItemsInput)
-	suite.Require().NoError(err, "Failed to put items")
-	putItemsOutput := response.Output.(*v3io.PutItemsOutput)
-	suite.Require().True(putItemsOutput.Success)
-	response.Release()
-
-	// update `scatteredItemKeys` items with big KV entries to force them to scatter
-	for _, key := range scatteredItemKeys {
-		updateItemInput := v3io.UpdateItemInput{
-			Path: fmt.Sprintf("%s/%s", path, key),
-		}
-
-		// because of request size limit we will have to update items in parts
-		for i := 0; i < 4; i++ {
-			attributes := map[string]interface{}{}
-			for j := 0; j < 30; j++ {
-				attributes[fmt.Sprintf("%s_%s_%d_%d", "blob", key, i, j)] = randomString(60000)
-			}
-			updateItemInput.Attributes = attributes
-			suite.populateDataPlaneInput(&updateItemInput.DataPlaneInput)
-			response, err := suite.container.UpdateItemSync(&updateItemInput)
-			suite.Require().NoError(err, "Failed to update item")
-			response.Release()
-		}
-	}
+	items, scatteredItemKeys := suite.populateScatteredItems(path)
 
 	// Get cursor
 	getItemsInput := v3io.GetItemsInput{
@@ -989,13 +948,61 @@ func (suite *syncKVTestSuite) TestScatteredCursor() {
 						blobCounter++
 					}
 				}
-				suite.Assert().Equal(4*30, blobCounter)
+				suite.Assert().Equal(10*30, blobCounter)
 			}
 		}
 	}
 
 	suite.deleteItems(items)
 }
+
+func (suite *syncKVTestSuite) TestIncludeResponseInError() {
+	path := "/emd0"
+
+	//items, scatteredItemKeys := suite.populateScatteredItems(path)
+	items, scatteredItemKeys := suite.populateScatteredItems(path)
+
+	// Get items with scattering disabled. Since there are scattered items this will create an error
+	getItemsInput := v3io.GetItemsInput{
+		Path:               path + "/",
+		AttributeNames:     []string{"**"},
+		AllowObjectScatter: "false",
+	}
+	suite.populateDataPlaneInput(&getItemsInput.DataPlaneInput)
+	getItemsInput.IncludeResponseInError = true
+
+	var err error
+	var response *v3io.Response
+	var errorItemKeys []string
+	totalItems := 0
+	for {
+		response, err = suite.container.GetItemsSync(&getItemsInput)
+		if response != nil {
+			getItemsOutput := response.Output.(*v3io.GetItemsOutput)
+			if getItemsOutput.Last {
+				break
+			}
+			suite.Assert().True(len(getItemsOutput.NextMarker) > 0)
+
+			if err != nil {
+				for _, item := range getItemsOutput.Items {
+					itemKey, _err := item.GetFieldString("__name")
+					suite.Assert().Nil(_err)
+					errorItemKeys = append(errorItemKeys, itemKey)
+				}
+			}
+
+			totalItems += len(getItemsOutput.Items)
+			getItemsInput.Marker = getItemsOutput.NextMarker
+		} else {
+			break
+		}
+	}
+
+	suite.Assert().Equal(len(items), totalItems)
+	suite.Assert().ElementsMatch(scatteredItemKeys, errorItemKeys)
+}
+
 
 func (suite *syncKVTestSuite) TestPutItemsWithError() {
 	items := map[string]map[string]interface{}{
@@ -1031,6 +1038,54 @@ func (suite *syncKVTestSuite) TestPutItemsWithError() {
 	suite.verifyItems(items)
 
 	suite.deleteItems(items)
+}
+
+func (suite *syncKVTestSuite) populateScatteredItems(path string) (map[string]map[string]interface{}, []string) {
+
+	scatteredItemKeys := []string{"louise", "karen"}
+	items := map[string]map[string]interface{}{
+		"bob":                {"age": 42, "feature": "mustache"},
+		"linda":              {"age": 41, "feature": "singing"},
+		"natan":              {"age": 35, "feature": "one leg"},
+		"donald":             {"age": 20, "feature": "teeth"},
+		scatteredItemKeys[0]: {"timestamp": time.Now().UnixNano(), "blob0": randomString(60000)},
+		scatteredItemKeys[1]: {"timestamp": time.Now().UnixNano(), "blob0": randomString(60000)},
+	}
+
+	putItemsInput := &v3io.PutItemsInput{
+		Path:  path,
+		Items: items,
+	}
+
+	// Store initial items
+	suite.populateDataPlaneInput(&putItemsInput.DataPlaneInput)
+	response, err := suite.container.PutItemsSync(putItemsInput)
+	suite.Require().NoError(err, "Failed to put items")
+	putItemsOutput := response.Output.(*v3io.PutItemsOutput)
+	suite.Require().True(putItemsOutput.Success)
+	response.Release()
+
+	// update `scatteredItemKeys` items with big KV entries to force them to scatter
+	for _, key := range scatteredItemKeys {
+		updateItemInput := v3io.UpdateItemInput{
+			Path: fmt.Sprintf("%s/%s", path, key),
+		}
+
+		// because of request size limit we will have to update items in parts
+		for i := 0; i < 10; i++ {
+			attributes := map[string]interface{}{}
+			for j := 0; j < 30; j++ {
+				attributes[fmt.Sprintf("%s_%s_%d_%d", "blob", key, i, j)] = randomString(60000)
+			}
+			updateItemInput.Attributes = attributes
+			suite.populateDataPlaneInput(&updateItemInput.DataPlaneInput)
+			response, err := suite.container.UpdateItemSync(&updateItemInput)
+			suite.Require().NoError(err, "Failed to update item")
+			response.Release()
+		}
+	}
+
+	return items, scatteredItemKeys
 }
 
 func (suite *syncKVTestSuite) verifyItems(items map[string]map[string]interface{}) {

--- a/pkg/dataplane/test/sync_test.go
+++ b/pkg/dataplane/test/sync_test.go
@@ -959,10 +959,9 @@ func (suite *syncKVTestSuite) TestScatteredCursor() {
 func (suite *syncKVTestSuite) TestIncludeResponseInError() {
 	path := "/emd0"
 
-	//items, scatteredItemKeys := suite.populateScatteredItems(path)
 	items, scatteredItemKeys := suite.populateScatteredItems(path)
 
-	// Get items with scattering disabled. Since there are scattered items this will create an error
+	// Issue GetItems request with scattering disabled. Since there are scattered items this will create an error
 	getItemsInput := v3io.GetItemsInput{
 		Path:               path + "/",
 		AttributeNames:     []string{"**"},

--- a/pkg/dataplane/test/sync_test.go
+++ b/pkg/dataplane/test/sync_test.go
@@ -973,7 +973,7 @@ func (suite *syncKVTestSuite) TestIncludeResponseInError() {
 	var err error
 	var response *v3io.Response
 	var errorItemKeys []string
-	totalItems := 0
+	receivedItems := 0
 	for {
 		response, err = suite.container.GetItemsSync(&getItemsInput)
 		if response != nil {
@@ -991,14 +991,14 @@ func (suite *syncKVTestSuite) TestIncludeResponseInError() {
 				}
 			}
 
-			totalItems += len(getItemsOutput.Items)
+			receivedItems += len(getItemsOutput.Items)
 			getItemsInput.Marker = getItemsOutput.NextMarker
 		} else {
 			break
 		}
 	}
 
-	suite.Assert().Equal(len(items), totalItems)
+	suite.Assert().Equal(len(items), receivedItems)
 	suite.Assert().ElementsMatch(scatteredItemKeys, errorItemKeys)
 }
 

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -45,12 +45,13 @@ type NewContainerInput struct {
 //
 
 type DataPlaneInput struct {
-	Ctx                 context.Context
-	URL                 string
-	ContainerName       string
-	AuthenticationToken string
-	AccessKey           string
-	Timeout             time.Duration
+	Ctx                    context.Context
+	URL                    string
+	ContainerName          string
+	AuthenticationToken    string
+	AccessKey              string
+	Timeout                time.Duration
+	IncludeResponseInError bool
 }
 
 type DataPlaneOutput struct {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,6 +2,9 @@ package v3ioerrors
 
 import (
 	"errors"
+
+	v3io "github.com/v3io/v3io-go/pkg/dataplane"
+	"github.com/valyala/fasthttp"
 )
 
 var ErrInvalidTypeConversion = errors.New("Invalid type conversion")
@@ -12,6 +15,11 @@ var ErrTimeout = errors.New("Timed out")
 type ErrorWithStatusCode struct {
 	error
 	statusCode int
+}
+
+type ErrorWithStatusCodeAndResponse struct {
+	ErrorWithStatusCode
+	response *v3io.Response
 }
 
 func NewErrorWithStatusCode(err error, statusCode int) ErrorWithStatusCode {
@@ -27,4 +35,33 @@ func (e ErrorWithStatusCode) StatusCode() int {
 
 func (e ErrorWithStatusCode) Error() string {
 	return e.error.Error()
+}
+
+func NewErrorWithStatusCodeAndResponse(err error,
+	statusCode int,
+	response *v3io.Response) ErrorWithStatusCodeAndResponse {
+
+	// Copy response struct since original response will be released if error is encountered
+	var _copiedResponse *v3io.Response
+	if response != nil {
+		copiedHTTPResponse := &fasthttp.Response{}
+		if response.HTTPResponse != nil {
+			response.HTTPResponse.CopyTo(copiedHTTPResponse)
+		}
+		_copiedResponse = &v3io.Response{
+			Output:       response.Output,
+			Context:      response.Context,
+			Error:        response.Error,
+			HTTPResponse: copiedHTTPResponse,
+		}
+	}
+
+	return ErrorWithStatusCodeAndResponse{
+		ErrorWithStatusCode: NewErrorWithStatusCode(err, statusCode),
+		response:            _copiedResponse,
+	}
+}
+
+func (e ErrorWithStatusCodeAndResponse) Response() *v3io.Response {
+	return e.response
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -2,8 +2,6 @@ package v3ioerrors
 
 import (
 	"errors"
-
-	v3io "github.com/v3io/v3io-go/pkg/dataplane"
 )
 
 var ErrInvalidTypeConversion = errors.New("Invalid type conversion")
@@ -18,7 +16,7 @@ type ErrorWithStatusCode struct {
 
 type ErrorWithStatusCodeAndResponse struct {
 	ErrorWithStatusCode
-	response *v3io.Response
+	response interface{}
 }
 
 func NewErrorWithStatusCode(err error, statusCode int) ErrorWithStatusCode {
@@ -38,7 +36,7 @@ func (e ErrorWithStatusCode) Error() string {
 
 func NewErrorWithStatusCodeAndResponse(err error,
 	statusCode int,
-	response *v3io.Response) ErrorWithStatusCodeAndResponse {
+	response interface{}) ErrorWithStatusCodeAndResponse {
 
 	return ErrorWithStatusCodeAndResponse{
 		ErrorWithStatusCode: NewErrorWithStatusCode(err, statusCode),
@@ -46,6 +44,6 @@ func NewErrorWithStatusCodeAndResponse(err error,
 	}
 }
 
-func (e ErrorWithStatusCodeAndResponse) Response() *v3io.Response {
+func (e ErrorWithStatusCodeAndResponse) Response() interface{} {
 	return e.response
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	v3io "github.com/v3io/v3io-go/pkg/dataplane"
-	"github.com/valyala/fasthttp"
 )
 
 var ErrInvalidTypeConversion = errors.New("Invalid type conversion")
@@ -41,24 +40,9 @@ func NewErrorWithStatusCodeAndResponse(err error,
 	statusCode int,
 	response *v3io.Response) ErrorWithStatusCodeAndResponse {
 
-	// Copy response struct since original response will be released if error is encountered
-	var _copiedResponse *v3io.Response
-	if response != nil {
-		copiedHTTPResponse := &fasthttp.Response{}
-		if response.HTTPResponse != nil {
-			response.HTTPResponse.CopyTo(copiedHTTPResponse)
-		}
-		_copiedResponse = &v3io.Response{
-			Output:       response.Output,
-			Context:      response.Context,
-			Error:        response.Error,
-			HTTPResponse: copiedHTTPResponse,
-		}
-	}
-
 	return ErrorWithStatusCodeAndResponse{
 		ErrorWithStatusCode: NewErrorWithStatusCode(err, statusCode),
-		response:            _copiedResponse,
+		response:            response,
 	}
 }
 


### PR DESCRIPTION
Include http response in error struct
This is needed since response may include `NextMarker` field which is required to skip items which caused an error