### PR TITLE
Retry getting shard in case of network instability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ test: check-env
 	GO111MODULE=on \
 		go test -race -tags unit -count 1 ./...
 
+.PHONY: fmt
+fmt:
+	gofmt -s -w .
+
 .PHONY: lint
 lint:
 	docker run --rm \

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -1,12 +1,15 @@
 package streamconsumergroup
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"path"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/v3io/v3io-go/pkg/common"
 	"github.com/v3io/v3io-go/pkg/dataplane"
 	v3ioerrors "github.com/v3io/v3io-go/pkg/errors"
 
@@ -21,6 +24,10 @@ type claim struct {
 	recordBatchChan          chan *RecordBatch
 	stopRecordBatchFetchChan chan struct{}
 	currentShardLocation     string
+
+	// get shard location configuration
+	getShardLocationAttempts int
+	getShardLocationBackoff  common.Backoff
 }
 
 func newClaim(member *member, shardID int) (*claim, error) {
@@ -30,6 +37,8 @@ func newClaim(member *member, shardID int) (*claim, error) {
 		shardID:                  shardID,
 		recordBatchChan:          make(chan *RecordBatch, member.streamConsumerGroup.config.Claim.RecordBatchChanSize),
 		stopRecordBatchFetchChan: make(chan struct{}, 1),
+		getShardLocationAttempts: member.streamConsumerGroup.config.Claim.GetShardLocationRetry.Attempts,
+		getShardLocationBackoff:  member.streamConsumerGroup.config.Claim.GetShardLocationRetry.Backoff,
 	}, nil
 }
 
@@ -93,12 +102,34 @@ func (c *claim) fetchRecordBatches(stopChannel chan struct{}, fetchInterval time
 	var err error
 
 	// read initial location. use config if error. might need to wait until shard actually exists
-	c.currentShardLocation, err = c.getCurrentShardLocation(c.shardID)
-	if err != nil {
-		if err == v3ioerrors.ErrStopped {
-			return nil
-		}
+	if err := common.RetryFunc(context.TODO(),
+		c.logger,
+		c.getShardLocationAttempts,
+		nil,
+		&c.getShardLocationBackoff, func(attempt int) (bool, error) {
+			c.currentShardLocation, err = c.getCurrentShardLocation(c.shardID)
+			if err != nil {
 
+				// requested for an immediate stop
+				if err == v3ioerrors.ErrStopped {
+					return false, nil
+				}
+
+				switch errors.RootCause(err).(type) {
+
+				// in case of a network error, retry to avoid transient errors
+				case *net.OpError:
+					return true, errors.Wrap(err, "Failed to get shard location due to a network error")
+
+				// unknown error, fail now
+				default:
+					return false, errors.Wrap(err, "Failed to get shard location")
+				}
+			}
+
+			// we have shard location
+			return false, nil
+		}); err != nil {
 		return errors.Wrap(err, "Failed to get shard location")
 	}
 

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -130,7 +130,9 @@ func (c *claim) fetchRecordBatches(stopChannel chan struct{}, fetchInterval time
 			// we have shard location
 			return false, nil
 		}); err != nil {
-		return errors.Wrap(err, "Failed to get shard location")
+		return errors.Wrapf(err,
+			"Failed to get shard location state, attempts exhausted. shard id: %s",
+			c.shardID)
 	}
 
 	for {
@@ -223,7 +225,7 @@ func (c *claim) getCurrentShardLocation(shardID int) (string, error) {
 	// get the location from persistency
 	currentShardLocation, err := c.member.streamConsumerGroup.getShardLocationFromPersistency(shardID)
 	if err != nil && errors.RootCause(err) != ErrShardNotFound {
-		return "", errors.Wrap(err, "Failed to get shard location")
+		return "", errors.Wrap(err, "Failed to get shard location from persistency")
 	}
 
 	// if shard wasn't found, try again periodically
@@ -243,7 +245,7 @@ func (c *claim) getCurrentShardLocation(shardID int) (string, error) {
 						continue
 					}
 
-					return "", errors.Wrap(err, "Failed to get shard location")
+					return "", errors.Wrap(err, "Failed to get shard location from persistency")
 				}
 
 				return currentShardLocation, nil

--- a/pkg/dataplane/streamconsumergroup/config.go
+++ b/pkg/dataplane/streamconsumergroup/config.go
@@ -29,6 +29,10 @@ type Config struct {
 			NumRecordsInBatch int                     `json:"numRecordsInBatch,omitempty"`
 			InitialLocation   v3io.SeekShardInputType `json:"initialLocation,omitempty"`
 		} `json:"recordBatchFetch,omitempty"`
+		GetShardLocationRetry struct {
+			Attempts int            `json:"attempts,omitempty"`
+			Backoff  common.Backoff `json:"backoff,omitempty"`
+		} `json:"getShardLocationRetry,omitempty"`
 	} `json:"claim,omitempty"`
 }
 
@@ -49,6 +53,12 @@ func NewConfig() *Config {
 	c.Claim.RecordBatchFetch.Interval = 250 * time.Millisecond
 	c.Claim.RecordBatchFetch.NumRecordsInBatch = 10
 	c.Claim.RecordBatchFetch.InitialLocation = v3io.SeekShardInputTypeEarliest
+	c.Claim.GetShardLocationRetry.Attempts = 100
+	c.Claim.GetShardLocationRetry.Backoff = common.Backoff{
+		Min:    50 * time.Millisecond,
+		Max:    1 * time.Second,
+		Factor: 2,
+	}
 
 	return c
 }

--- a/pkg/dataplane/test/sync_test.go
+++ b/pkg/dataplane/test/sync_test.go
@@ -946,7 +946,7 @@ func (suite *syncKVTestSuite) TestScatteredCursor() {
 
 				// count number of blob keys
 				blobCounter := 0
-				for key, _ := range retrievedItem {
+				for key := range retrievedItem {
 					if strings.HasPrefix(key, "blob_") {
 						blobCounter++
 					}


### PR DESCRIPTION
When starting to consume from a stream, we fetch some stream metadata from v3io server. when failing doing so, the entire process of consuming from a stream being left in bad shape.
To  provide resiliency and avoid failures in case of transient network errors, it is desired to retry for a while.
