### PR TITLE
Tests - Fix controlplane tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# To setup env locally on your dev box, run:
+# $ export $(grep -v '^#' ./hack/test.env | xargs)
 .PHONY: check-env
 check-env:
 ifndef V3IO_DATAPLANE_URL
@@ -46,7 +48,7 @@ lint:
 
 .PHONY: test-controlplane
 test-controlplane: check-env
-	go test -race -tags unit -count 1 ./pkg/controlplane/...
+	go test -test.v=true -race -tags unit -count 1 ./pkg/controlplane/...
 
 .PHONY: build
 build: clean generate-capnp lint test

--- a/pkg/controlplane/test/controlplane_test.go
+++ b/pkg/controlplane/test/controlplane_test.go
@@ -95,7 +95,7 @@ func (suite *testSuite) SetupTest() {
 	suite.ctx = context.WithValue(context.TODO(), "RequestID", "test-0")
 }
 
-func (suite *testSuite) TestCreateContainerStringID() {
+func (suite *testSuite) TestCreateContainer() {
 	createContainerInput := v3ioc.CreateContainerInput{}
 	createContainerInput.Ctx = suite.ctx
 	createContainerInput.Name = "container-string"
@@ -103,27 +103,6 @@ func (suite *testSuite) TestCreateContainerStringID() {
 	createContainerOutput, err := suite.session.CreateContainerSync(&createContainerInput)
 	suite.Require().NoError(err)
 	suite.Require().NotEqual(0, createContainerOutput.IDNumeric)
-
-	time.Sleep(5 * time.Second)
-
-	deleteContainerInput := v3ioc.DeleteContainerInput{}
-	deleteContainerInput.Ctx = suite.ctx
-	deleteContainerInput.IDNumeric = createContainerOutput.IDNumeric
-
-	err = suite.session.DeleteContainerSync(&deleteContainerInput)
-	suite.Require().NoError(err)
-}
-
-// will be deprecated in upcoming versions
-func (suite *testSuite) TestCreateContainerNumericID() {
-	createContainerInput := v3ioc.CreateContainerInput{}
-	createContainerInput.Ctx = suite.ctx
-	createContainerInput.IDNumeric = 300
-	createContainerInput.Name = "container-int"
-
-	createContainerOutput, err := suite.session.CreateContainerSync(&createContainerInput)
-	suite.Require().NoError(err)
-	suite.Require().Equal(createContainerInput.IDNumeric, createContainerOutput.IDNumeric)
 
 	time.Sleep(5 * time.Second)
 
@@ -206,19 +185,19 @@ func (suite *testSuite) TestReloadConfigurations() {
 	timeout := 2 * time.Minute
 	var err error
 
-	suite.logger.InfoWith(context.TODO(), "Reloading cluster configuration")
+	suite.logger.InfoWith("Reloading cluster configuration")
 	err = session.ReloadClusterConfigAndWaitForCompletion(context.TODO(), retryInterval, timeout)
 	suite.Require().NoError(err)
 
-	suite.logger.InfoWith(context.TODO(), "Reloading events configuration")
+	suite.logger.InfoWith("Reloading events configuration")
 	err = session.ReloadEventsConfigAndWaitForCompletion(context.TODO(), retryInterval, timeout)
 	suite.Require().NoError(err)
 
-	suite.logger.InfoWith(context.TODO(), "Reloading app services configuration")
+	suite.logger.InfoWith("Reloading app services configuration")
 	err = session.ReloadAppServicesConfigAndWaitForCompletion(context.TODO(), retryInterval, timeout)
 	suite.Require().NoError(err)
 
-	suite.logger.InfoWith(context.TODO(), "Reloading artifact version manifest configuration")
+	suite.logger.InfoWith("Reloading artifact version manifest configuration")
 	err = session.ReloadArtifactVersionManifestAndWaitForCompletion(context.TODO(), retryInterval, timeout)
 	suite.Require().NoError(err)
 }


### PR DESCRIPTION
Fixing existing breakages (`make test-controlplane` now passes):
- Typo in some logging calls
- Deprecated create container by ID logic (no longer supported as of 3.0)
- Added verbose flag to makefile so we can see debug logs