### PR TITLE
Stream Consumer Group - Shard retention mechanism

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.1.0 h1:9Z322kTPrDR5GpxTH+1yl7As6tEHIH9aGsRccl20ELk=
 github.com/rs/xid v1.1.0/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -43,7 +43,7 @@ func newClaim(member *member, shardID int) (*claim, error) {
 }
 
 func (c *claim) start() error {
-	c.logger.DebugWith("Starting claim")
+	c.logger.DebugWith("Starting claim", "shardID", c.shardID)
 
 	go func() {
 		err := c.fetchRecordBatches(c.stopRecordBatchFetchChan,

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -102,3 +102,8 @@ func (m *member) Close() error {
 
 	return nil
 }
+
+// TOMER - only for debugging
+func (m *member) GetShardGroup() []int {
+	return m.shardGroup
+}

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -49,8 +49,7 @@ func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (M
 		return nil, errors.Wrap(err, "Failed creating stream consumer group location handler")
 	}
 
-	err = newMember.Start()
-	if err != nil {
+	if err := newMember.Start(); err != nil {
 		return nil, errors.Wrap(err, "Failed starting new member")
 	}
 

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -16,6 +16,8 @@ type member struct {
 	sequenceNumberHandler *sequenceNumberHandler
 	handler               Handler
 	session               Session
+	retainShards          bool
+	shardGroup            []int
 }
 
 func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (Member, error) {
@@ -46,7 +48,7 @@ func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (M
 		return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
 	}
 
-	// create & start an location handler for the stream
+	// create & start a location handler for the stream
 	newMember.sequenceNumberHandler, err = newSequenceNumberHandler(&newMember)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating stream consumer group location handler")

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -43,22 +43,11 @@ func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (M
 		return nil, errors.Wrap(err, "Failed creating stream consumer group state handler")
 	}
 
-	//err = newMember.stateHandler.start()
-	//if err != nil {
-	//	return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
-	//}
-
 	// create & start a location handler for the stream
 	newMember.sequenceNumberHandler, err = newSequenceNumberHandler(&newMember)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed creating stream consumer group location handler")
 	}
-
-	// if there's no member name, just observe
-	//err = newMember.sequenceNumberHandler.start()
-	//if err != nil {
-	//	return nil, errors.Wrap(err, "Failed starting stream consumer group state handler")
-	//}
 
 	err = newMember.Start()
 	if err != nil {

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -92,8 +92,6 @@ func (m *member) Consume(handler Handler) error {
 func (m *member) Close() error {
 	m.logger.DebugWith("Closing consumer group")
 
-	m.retainShards = false
-
 	if err := m.stateHandler.stop(); err != nil {
 		return errors.Wrapf(err, "Failed stopping state handler")
 	}

--- a/pkg/dataplane/streamconsumergroup/member.go
+++ b/pkg/dataplane/streamconsumergroup/member.go
@@ -17,7 +17,7 @@ type member struct {
 	handler               Handler
 	session               Session
 	retainShards          bool
-	shardGroup            []int
+	shardGroupToRetain    []int
 }
 
 func NewMember(streamConsumerGroupInterface StreamConsumerGroup, name string) (Member, error) {
@@ -101,9 +101,4 @@ func (m *member) Close() error {
 	}
 
 	return nil
-}
-
-// TOMER - only for debugging
-func (m *member) GetShardGroup() []int {
-	return m.shardGroup
 }

--- a/pkg/dataplane/streamconsumergroup/session.go
+++ b/pkg/dataplane/streamconsumergroup/session.go
@@ -25,7 +25,7 @@ func newSession(member *member,
 }
 
 func (s *session) start() error {
-	s.logger.DebugWith("Starting session")
+	s.logger.DebugWith("Starting session", "shards", s.state.Shards)
 
 	// for each shard we need handle, create a StreamConsumerGroupClaim object and start it
 	for _, shardID := range s.state.Shards {

--- a/pkg/dataplane/streamconsumergroup/statehandler.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler.go
@@ -157,7 +157,6 @@ func (sh *stateHandler) refreshState() (*State, error) {
 
 		// session already exists - just set the last heartbeat
 		if sessionState != nil {
-			//sh.logger.Debug("TOMER - session state exists, updating heartbeat")
 			sessionState.LastHeartbeat = time.Now()
 
 			// we're done
@@ -165,7 +164,6 @@ func (sh *stateHandler) refreshState() (*State, error) {
 		}
 
 		// session doesn't exist - create it
-		sh.logger.Debug("TOMER - session doesn't exist - create it")
 		if err := sh.createSessionState(state); err != nil {
 			return nil, errors.Wrap(err, "Failed to create session state")
 		}
@@ -190,9 +188,6 @@ func (sh *stateHandler) createSessionState(state *State) error {
 	var err error
 
 	if sh.member.retainShards {
-		sh.logger.DebugWith("TOMER - Member trying to retain shards",
-			"memberID", sh.member.id,
-			"shardGroupToRetain", sh.member.shardGroupToRetain)
 
 		// try to retain the originally assigned shard group
 		shards, err = sh.retainShards(sh.member.shardGroupToRetain, sh.member.id, state)
@@ -207,9 +202,6 @@ func (sh *stateHandler) createSessionState(state *State) error {
 			return err
 		}
 	} else {
-
-		sh.logger.DebugWith("TOMER - Member doesn't need to retain shards, assigning",
-			"memberID", sh.member.id)
 
 		// assign shards
 		shards, err = sh.assignShards(sh.member.streamConsumerGroup.maxReplicas, sh.member.streamConsumerGroup.totalNumShards, state)
@@ -328,7 +320,6 @@ func (sh *stateHandler) getAssignEmptyShardGroup(replicaShardGroups [][]int, sta
 }
 
 func (sh *stateHandler) removeStaleSessionStates(state *State) error {
-	//sh.logger.Debug("TOMER - removing stale session states")
 
 	// clear out the sessions since we only want the valid sessions
 	var activeSessionStates []*SessionState

--- a/pkg/dataplane/streamconsumergroup/statehandler.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler.go
@@ -43,6 +43,7 @@ func (sh *stateHandler) start() error {
 			if errors.RootCause(err) == errShardRetention {
 
 				// signal that the Handler needs to be restarted
+				sh.logger.DebugWith("Aborting member", "memberID", sh.member.id)
 				sh.member.handler.Abort(sh.member.session) // nolint: errcheck
 			}
 		}

--- a/pkg/dataplane/streamconsumergroup/statehandler.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler.go
@@ -208,6 +208,9 @@ func (sh *stateHandler) createSessionState(state *State) error {
 		}
 	} else {
 
+		sh.logger.DebugWith("TOMER - Member doesn't need to retain shards, assigning",
+			"memberID", sh.member.id)
+
 		// assign shards
 		shards, err = sh.assignShards(sh.member.streamConsumerGroup.maxReplicas, sh.member.streamConsumerGroup.totalNumShards, state)
 		if err != nil {

--- a/pkg/dataplane/streamconsumergroup/statehandler_test.go
+++ b/pkg/dataplane/streamconsumergroup/statehandler_test.go
@@ -1,6 +1,7 @@
 package streamconsumergroup
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -74,6 +75,58 @@ func (suite *stateHandlerSuite) TestAssignShards() {
 		assignedShardGroup, err := suite.stateHandler.assignShards(testCase.maxReplicas, testCase.numShards, &state)
 		suite.Require().NoError(err)
 		suite.Require().Equal(testCase.expectedShardGroup, assignedShardGroup, testCase.name)
+	}
+}
+
+func (suite *stateHandlerSuite) TestRetainShards() {
+	for _, testCase := range []struct {
+		name                string
+		memberID            string
+		existingShardGroups [][]int
+		expectedShardGroup  []int
+		expectedError       bool
+	}{
+		{
+			name:                "successfulRetention",
+			memberID:            "1",
+			existingShardGroups: [][]int{{0, 1}, {2, 3}},
+			expectedShardGroup:  []int{2, 3},
+			expectedError:       false,
+		},
+		{
+			name:                "failedRetention",
+			memberID:            "2",
+			existingShardGroups: [][]int{{0, 1}, {2, 3}, {4, 5}},
+			expectedShardGroup:  []int{0, 1},
+			expectedError:       true,
+		},
+		{
+			name:                "unexpectedBehaviour",
+			memberID:            "0",
+			existingShardGroups: [][]int{{0, 1}, {2, 3}},
+			expectedShardGroup:  []int{4, 5},
+			expectedError:       true,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+
+			// make state from shard groups
+			state := State{}
+			for i, existingShardGroup := range testCase.existingShardGroups {
+				state.SessionStates = append(state.SessionStates, &SessionState{
+					Shards:   existingShardGroup,
+					MemberID: strconv.Itoa(i),
+				})
+			}
+
+			shards, err := suite.stateHandler.retainShards(testCase.expectedShardGroup, testCase.memberID, &state)
+			if testCase.expectedError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Require().ElementsMatch(testCase.expectedShardGroup, shards)
+			}
+		})
 	}
 }
 

--- a/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
+++ b/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
@@ -110,6 +110,11 @@ func (scg *streamConsumerGroup) setState(modifier stateModifier) (*State, error)
 
 		modifiedState, err = modifier(state)
 		if err != nil {
+			if errors.Cause(err) == errShardRetention {
+
+				// if shard retention failed, member needs to be restarted, so we can stop retrying
+				return false, errors.Wrap(errShardRetention, "Failed modifying state")
+			}
 			return true, errors.Wrap(err, "Failed modifying state")
 		}
 

--- a/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
+++ b/pkg/dataplane/streamconsumergroup/streamconsumergroup.go
@@ -112,8 +112,8 @@ func (scg *streamConsumerGroup) setState(modifier stateModifier) (*State, error)
 		if err != nil {
 			if errors.Cause(err) == errShardRetention {
 
-				// if shard retention failed, member needs to be restarted, so we can stop retrying
-				return false, errors.Wrap(errShardRetention, "Failed modifying state")
+				// if shard retention failed the member needs to be aborted, so we can stop retrying
+				return false, errors.Wrap(err, "Failed modifying state")
 			}
 			return true, errors.Wrap(err, "Failed modifying state")
 		}

--- a/pkg/dataplane/streamconsumergroup/types.go
+++ b/pkg/dataplane/streamconsumergroup/types.go
@@ -27,6 +27,9 @@ type Handler interface {
 	// Once the Messages() channel is closed, the Handler must finish its processing
 	// loop and exit.
 	ConsumeClaim(Session, Claim) error
+
+	// SignalRestart is used to signal that the handler needs to be restarted
+	SignalRestart(Session) error
 }
 
 type RecordBatch struct {

--- a/pkg/dataplane/streamconsumergroup/types.go
+++ b/pkg/dataplane/streamconsumergroup/types.go
@@ -28,8 +28,8 @@ type Handler interface {
 	// loop and exit.
 	ConsumeClaim(Session, Claim) error
 
-	// SignalRestart is used to signal that the handler needs to be restarted
-	SignalRestart(Session) error
+	// Abort is used to signal that the handler needs to be aborted
+	Abort(Session) error
 }
 
 type RecordBatch struct {

--- a/pkg/dataplane/streamconsumergroup/types.go
+++ b/pkg/dataplane/streamconsumergroup/types.go
@@ -48,6 +48,10 @@ type StreamConsumerGroup interface {
 type Member interface {
 	Consume(Handler) error
 	Close() error
+	Start() error
+	GetID() string
+	GetRetainShardFlag() bool
+	GetShardsToRetain() []int
 }
 
 type Session interface {

--- a/pkg/dataplane/streamconsumergroup/types.go
+++ b/pkg/dataplane/streamconsumergroup/types.go
@@ -8,6 +8,8 @@ import (
 
 type stateModifier func(*State) (*State, error)
 
+type postSetStateInPersistencyHandler func() error
+
 type SessionState struct {
 	MemberID      string    `json:"member_id"`
 	LastHeartbeat time.Time `json:"last_heartbeat_time"`
@@ -28,7 +30,7 @@ type Handler interface {
 	// loop and exit.
 	ConsumeClaim(Session, Claim) error
 
-	// Abort is used to signal that the handler needs to be aborted
+	// Abort signals the handler to start abort procedure
 	Abort(Session) error
 }
 

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -393,8 +393,8 @@ func (m *member) ConsumeClaim(session streamconsumergroup.Session, claim streamc
 	return nil
 }
 
-func (m *member) SignalRestart(session streamconsumergroup.Session) error {
-	m.logger.DebugWith("SignalRestart called")
+func (m *member) Abort(session streamconsumergroup.Session) error {
+	m.logger.DebugWith("Abort called")
 	return nil
 }
 

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -393,6 +393,11 @@ func (m *member) ConsumeClaim(session streamconsumergroup.Session, claim streamc
 	return nil
 }
 
+func (m *member) SignalRestart(session streamconsumergroup.Session) error {
+	m.logger.DebugWith("SignalRestart called")
+	return nil
+}
+
 func (m *member) start(expectedStartRecordIndex []int, numberOfRecordToConsume []int) {
 	m.expectedStartRecordIndex = expectedStartRecordIndex
 	m.numberOfRecordToConsume = numberOfRecordToConsume

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -170,11 +170,11 @@ func (suite *streamConsumerGroupTestSuite) TestStateHandlerRetainShards() {
 	// stop
 	for i := 0; i < members/2; i++ {
 		member := memberGroup.members[i]
-		suite.logger.DebugWith("TOMER - Stopping member", "memberID", member.streamConsumerGroupMember.GetID())
+		suite.logger.DebugWith("Stopping member", "memberID", member.streamConsumerGroupMember.GetID())
 
 		// copy shardsToRetain list for every member
 		if member.streamConsumerGroupMember.GetRetainShardFlag() {
-			suite.logger.DebugWith("TOMER - member needs to retain flag, saving shardsToRetain",
+			suite.logger.DebugWith("member needs to retain flag, saving shardsToRetain",
 				"memberID", member.streamConsumerGroupMember.GetID(),
 				"shardsToRetain", member.streamConsumerGroupMember.GetShardsToRetain())
 			originalShardGroups[member.streamConsumerGroupMember.GetID()] = make([]int, len(member.streamConsumerGroupMember.GetShardsToRetain()))
@@ -233,7 +233,7 @@ func (suite *streamConsumerGroupTestSuite) TestStateHandlerRetainShards() {
 	startMembersErrGroup, _ := errgroup.WithContext(context.TODO())
 	for i := 0; i < members/2; i++ {
 		member := memberGroup.members[i]
-		suite.logger.DebugWith("TOMER - Starting member", "memberID", member.streamConsumerGroupMember.GetID())
+		suite.logger.DebugWith("Starting member", "memberID", member.streamConsumerGroupMember.GetID())
 		startMembersErrGroup.Go(func() error {
 			if err := member.streamConsumerGroupMember.Start(); err != nil {
 				return err

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -498,8 +498,7 @@ func (suite *streamConsumerGroupTestSuite) getStateFromPersistency(streamPath, c
 
 	var state streamconsumergroup.State
 
-	err = json.Unmarshal([]byte(stateContents), &state)
-	if err != nil {
+	if err := json.Unmarshal([]byte(stateContents), &state); err != nil {
 		return nil, err
 	}
 
@@ -512,7 +511,7 @@ func (suite *testSuite) setStateInPersistency(streamPath, consumerGroupName stri
 		return err
 	}
 
-	if _, err = suite.container.UpdateItemSync(&v3io.UpdateItemInput{
+	if _, err := suite.container.UpdateItemSync(&v3io.UpdateItemInput{
 		Path: path.Join(streamPath, fmt.Sprintf("%s-state.json", consumerGroupName)),
 		Attributes: map[string]interface{}{
 			"state": string(stateContents),

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -512,13 +512,12 @@ func (suite *testSuite) setStateInPersistency(streamPath, consumerGroupName stri
 		return err
 	}
 
-	_, err = suite.container.UpdateItemSync(&v3io.UpdateItemInput{
+	if _, err = suite.container.UpdateItemSync(&v3io.UpdateItemInput{
 		Path: path.Join(streamPath, fmt.Sprintf("%s-state.json", consumerGroupName)),
 		Attributes: map[string]interface{}{
 			"state": string(stateContents),
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -721,9 +720,6 @@ func (m *member) Abort(session streamconsumergroup.Session) error {
 	m.logger.DebugWith("Abort called", "memberID", m.streamConsumerGroupMember.GetID())
 	m.Called(session)
 	m.stop()
-	//expectedStartRecordIndex := m.expectedStartRecordIndex
-	//numberOfRecordToConsume := m.numberOfRecordToConsume
-	//m.start(expectedStartRecordIndex, numberOfRecordToConsume)
 	return nil
 }
 

--- a/pkg/dataplane/test/streamconsumergroup_test.go
+++ b/pkg/dataplane/test/streamconsumergroup_test.go
@@ -203,6 +203,21 @@ func (suite *streamConsumerGroupTestSuite) verifyShardSequenceNumbers(numShards 
 	}
 }
 
+////
+//// shard retention tests
+////
+//
+//type shardRetentionTestSuite struct {
+//	testSuite
+//}
+//
+//func (suite *shardRetentionTestSuite) TestShardRetention() {
+//
+//	member := member{
+//
+//	}
+//}
+
 //
 // Orchestrates a group of members
 //
@@ -395,6 +410,7 @@ func (m *member) ConsumeClaim(session streamconsumergroup.Session, claim streamc
 
 func (m *member) Abort(session streamconsumergroup.Session) error {
 	m.logger.DebugWith("Abort called")
+	m.stop()
 	return nil
 }
 
@@ -424,4 +440,5 @@ func (m *member) getShardIDs() []int {
 
 func TestStreamConsumerGroupTestSuite(t *testing.T) {
 	suite.Run(t, new(streamConsumerGroupTestSuite))
+	//suite.Run(t, new(shardRetentionTestSuite))
 }

--- a/pkg/dataplane/test/test.go
+++ b/pkg/dataplane/test/test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/v3io/v3io-go/pkg/dataplane"
 	"github.com/v3io/v3io-go/pkg/dataplane/http"
-	"github.com/v3io/v3io-go/pkg/errors"
+	v3ioerrors "github.com/v3io/v3io-go/pkg/errors"
 
 	"github.com/nuclio/logger"
 	"github.com/nuclio/zap"


### PR DESCRIPTION
It is observed that members can steal shards from other members due to other members being stale falsely.

We introduce a Shard Retention Mechanism:
If a certain replica is assigned to a shard group, and comes back after an error - try to grab the same shard group (the original one).
If it succeeds - no problem.
If it fails (due to another replica stealing the shard group - can only happen during shard assignment) - the replica will kill itself.

Requirement: https://jira.iguazeng.com/browse/IG-20025
Nuclio PR: https://github.com/nuclio/nuclio/pull/2484