### PR TITLE
[Claim] Add arrival time to Stream Record batch

### DIFF
--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -217,11 +217,13 @@ func (c *claim) fetchRecordBatch(location string) (string, error) {
 
 	for receivedRecordIndex, receivedRecord := range getRecordsOutput.Records {
 		record := v3io.StreamRecord{
-			ShardID:        &c.shardID,
-			Data:           receivedRecord.Data,
-			ClientInfo:     receivedRecord.ClientInfo,
-			PartitionKey:   receivedRecord.PartitionKey,
-			SequenceNumber: receivedRecord.SequenceNumber,
+			ShardID:         &c.shardID,
+			Data:            receivedRecord.Data,
+			ClientInfo:      receivedRecord.ClientInfo,
+			PartitionKey:    receivedRecord.PartitionKey,
+			SequenceNumber:  receivedRecord.SequenceNumber,
+			ArrivalTimeSec:  receivedRecord.ArrivalTimeSec,
+			ArrivalTimeNSec: receivedRecord.ArrivalTimeNSec,
 		}
 
 		records[receivedRecordIndex] = record

--- a/pkg/dataplane/types.go
+++ b/pkg/dataplane/types.go
@@ -326,11 +326,13 @@ type GetItemsOutput struct {
 //
 
 type StreamRecord struct {
-	ShardID        *int
-	Data           []byte
-	ClientInfo     []byte
-	PartitionKey   string
-	SequenceNumber uint64
+	ShardID         *int
+	Data            []byte
+	ClientInfo      []byte
+	PartitionKey    string
+	SequenceNumber  uint64
+	ArrivalTimeSec  int
+	ArrivalTimeNSec int
 }
 
 type SeekShardInputType int


### PR DESCRIPTION
Add the arrival time so consumer will be able to refer to the actual time of the event arriving on the stream.

Resolves one part of https://jira.iguazeng.com/browse/NUC-111