### PR TITLE
Move checks for errors

### DIFF
--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -192,13 +192,6 @@ func EngineErrorIsNonFatal(err error) bool {
 	return errorMatches(err, nonFatalEngineErrorsPartialMatch)
 }
 
-func EngineErrorNeedsIndefiniteRetry(err error) bool {
-	var fatalEngineErrorsPartialMatch = []string{
-		"lookup v3io-webapi: i/o timeout",
-	}
-	return errorMatches(err, fatalEngineErrorsPartialMatch)
-}
-
 func errorMatches(err error, substrings []string) bool {
 	if err != nil && len(err.Error()) > 0 {
 		for _, substring := range substrings {

--- a/pkg/common/helper.go
+++ b/pkg/common/helper.go
@@ -192,7 +192,7 @@ func EngineErrorIsNonFatal(err error) bool {
 	return errorMatches(err, nonFatalEngineErrorsPartialMatch)
 }
 
-func EngineErrorIsFatal(err error) bool {
+func EngineErrorNeedsIndefiniteRetry(err error) bool {
 	var fatalEngineErrorsPartialMatch = []string{
 		"lookup v3io-webapi: i/o timeout",
 	}

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -130,20 +130,13 @@ func (c *claim) fetchRecordBatches(stopChannel chan struct{}, fetchInterval time
 		func(attempt int) (bool, error, int) {
 			c.currentShardLocation, err = c.getCurrentShardLocation(c.shardID)
 			if err != nil {
-				// if the error is fatal and requires external resolution,
+				// if the error is not fatal (as network issue),
 				// we don't want to fail; instead, we will inform the user via a log
-				if common.EngineErrorNeedsIndefiniteRetry(err) {
-					c.logger.ErrorWith("Failed to get shard location. Will retry until successful",
-						"error", err,
-						"shard", c.shardID)
+				if common.EngineErrorIsNonFatal(err) {
 					// for this type of error, we always increment the attempt counter
 					// this ensures the smooth operation of other components in Nuclio
 					// we avoid panicking and simply wait for the issue to be resolved
-					return true, errors.Wrap(err, "Failed to get shard location"), 1
-				}
-
-				if common.EngineErrorIsNonFatal(err) {
-					return true, errors.Wrap(err, "Failed to get shard location due to a network error"), 0
+					return true, errors.Wrap(err, "Failed to get shard location due to a network error"), 1
 				}
 
 				// requested for an immediate stop

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -133,6 +133,9 @@ func (c *claim) fetchRecordBatches(stopChannel chan struct{}, fetchInterval time
 				// if the error is not fatal (as network issue),
 				// we don't want to fail; instead, we will inform the user via a log
 				if common.EngineErrorIsNonFatal(err) {
+					c.logger.ErrorWith("Failed to get shard location. Will retry until successful",
+						"error", err,
+						"shard", c.shardID)
 					// for this type of error, we always increment the attempt counter
 					// this ensures the smooth operation of other components in Nuclio
 					// we avoid panicking and simply wait for the issue to be resolved

--- a/pkg/dataplane/streamconsumergroup/claim.go
+++ b/pkg/dataplane/streamconsumergroup/claim.go
@@ -130,20 +130,20 @@ func (c *claim) fetchRecordBatches(stopChannel chan struct{}, fetchInterval time
 		func(attempt int) (bool, error, int) {
 			c.currentShardLocation, err = c.getCurrentShardLocation(c.shardID)
 			if err != nil {
-				if common.EngineErrorIsNonFatal(err) {
-					return true, errors.Wrap(err, "Failed to get shard location due to a network error"), 0
-				}
-
 				// if the error is fatal and requires external resolution,
 				// we don't want to fail; instead, we will inform the user via a log
-				if common.EngineErrorIsFatal(err) {
-					c.logger.ErrorWith("A fatal error occurred. Will retry until successful",
+				if common.EngineErrorNeedsIndefiniteRetry(err) {
+					c.logger.ErrorWith("Failed to get shard location. Will retry until successful",
 						"error", err,
 						"shard", c.shardID)
 					// for this type of error, we always increment the attempt counter
 					// this ensures the smooth operation of other components in Nuclio
 					// we avoid panicking and simply wait for the issue to be resolved
 					return true, errors.Wrap(err, "Failed to get shard location"), 1
+				}
+
+				if common.EngineErrorIsNonFatal(err) {
+					return true, errors.Wrap(err, "Failed to get shard location due to a network error"), 0
 				}
 
 				// requested for an immediate stop


### PR DESCRIPTION
Changed as it turned out not to be external dependency issue, because nuclio function restart fixes the problem. Thus, in case of network issue, we will wait forever and inform about this in the log